### PR TITLE
Database Service - Handle Devices Only

### DIFF
--- a/BEIMA.Backend.Test/MongoConnectorTest.cs
+++ b/BEIMA.Backend.Test/MongoConnectorTest.cs
@@ -37,32 +37,11 @@ namespace BEIMA.Backend.Test
                     Environment.SetEnvironmentVariable(setting.Key, setting.Value);
                 }
             }
-            catch (Exception ex)
+            catch (DirectoryNotFoundException ex)
             {
                 Console.WriteLine(ex.ToString());
             }
             
-        }
-
-        [OneTimeTearDown]
-        public void OneTimeTearDown()
-        {
-        }
-
-        [SetUp]
-        public void SetUp()
-        {
-        }
-
-        [TearDown]
-        public void TearDown()
-        {
-        }
-
-        [Test]
-        public void InitialState_Action_ExpectedResult()
-        {
-            Assert.IsTrue(true);
         }
 
         [Test]
@@ -74,10 +53,10 @@ namespace BEIMA.Backend.Test
             var connector3 = MongoConnector.Instance;
             var connector4 = MongoConnector.Instance;
             var connector5 = MongoConnector.Instance;
-            Assert.IsTrue(connector1 == connector2);
-            Assert.IsTrue(connector1 == connector3);
-            Assert.IsTrue(connector1 == connector4);
-            Assert.IsTrue(connector1 == connector5);
+            Assert.That(connector1, Is.EqualTo(connector2));
+            Assert.That(connector1, Is.EqualTo(connector3));
+            Assert.That(connector1, Is.EqualTo(connector4));
+            Assert.That(connector1, Is.EqualTo(connector5));
         }
 
         [Test]

--- a/BEIMA.Backend.Test/MongoConnectorTest.cs
+++ b/BEIMA.Backend.Test/MongoConnectorTest.cs
@@ -81,37 +81,17 @@ namespace BEIMA.Backend.Test
         }
 
         [Test]
-        public void ConnectorCreated_GetDeviceGivenInvalidDeviceId_NullReturned()
+        public void ConnectorNotCreated_CallConstructorOnce_InstanceConnectedToCorrectEnvironment()
         {
             var mongo = MongoConnector.Instance;
-            //This is a valid ObjectId, but this is not in the database
-            var doc = mongo.GetDevice(new ObjectId("61f4882f42dab933544849d3"));
-            Assert.IsNull(doc);
-        }
-
-        [Test]
-        public void ConnectorCreated_DeleteInvalidObject_FalseReturned()
-        {
-            var mongo = MongoConnector.Instance;
-            //This is a valid ObjectId, but this is not in the database
-            var result = mongo.DeleteDevice(new ObjectId("61f4882f42dab933544849d3"));
-            Assert.IsFalse(result);
-        }
-
-        [Test]
-        public void ConnectorCreated_InsertNull_NullReturned()
-        {
-            var mongo = MongoConnector.Instance;
-            var result = mongo.InsertDevice(null);
-            Assert.IsNull(result);
-        }
-
-        [Test]
-        public void ConnectorCreated_UpdateNull_NullReturned()
-        {
-            var mongo = MongoConnector.Instance;
-            var result = mongo.UpdateDevice(null);
-            Assert.IsFalse(result);
+            if (Environment.GetEnvironmentVariable("CurrentEnv") == "dev-local")
+            {
+                Assert.IsTrue(mongo.CurrentServerType == ServerType.Local);
+            }
+            else
+            {
+                Assert.IsTrue(mongo.CurrentServerType == ServerType.Cloud);
+            }
         }
 
         [Test]
@@ -150,20 +130,6 @@ namespace BEIMA.Backend.Test
             var retrievedDocs = mongo.GetAllDevices();
             Assert.IsNotNull(retrievedDocs);
             Assert.IsTrue(retrievedDocs is List<BsonDocument>);
-        }
-
-        [Test]
-        public void ConnectorNotCreated_CallConstructorOnce_InstanceConnectedToCorrectEnvironment()
-        {
-            var mongo = MongoConnector.Instance;
-            if (Environment.GetEnvironmentVariable("CurrentEnv") == "dev-local")
-            {
-                Assert.IsTrue(mongo.CurrentServerType == ServerType.Local);
-            }
-            else
-            {
-                Assert.IsTrue(mongo.CurrentServerType == ServerType.Cloud);
-            }
         }
 
         [Test]
@@ -221,6 +187,40 @@ namespace BEIMA.Backend.Test
             doc.AddRange(new BsonDocument { { "updatedDeviceField", "123" } });
             var updateResult = mongo.UpdateDevice(doc);
             Assert.IsTrue(updateResult);
+        }
+
+        [Test]
+        public void ConnectorCreated_GetDeviceGivenInvalidDeviceId_NullReturned()
+        {
+            var mongo = MongoConnector.Instance;
+            //This is a valid ObjectId, but this is not in the database
+            var doc = mongo.GetDevice(new ObjectId("61f4882f42dab933544849d3"));
+            Assert.IsNull(doc);
+        }
+
+        [Test]
+        public void ConnectorCreated_DeleteInvalidObject_FalseReturned()
+        {
+            var mongo = MongoConnector.Instance;
+            //This is a valid ObjectId, but this is not in the database
+            var result = mongo.DeleteDevice(new ObjectId("61f4882f42dab933544849d3"));
+            Assert.IsFalse(result);
+        }
+
+        [Test]
+        public void ConnectorCreated_InsertNull_NullReturned()
+        {
+            var mongo = MongoConnector.Instance;
+            var result = mongo.InsertDevice(null);
+            Assert.IsNull(result);
+        }
+
+        [Test]
+        public void ConnectorCreated_UpdateNull_NullReturned()
+        {
+            var mongo = MongoConnector.Instance;
+            var result = mongo.UpdateDevice(null);
+            Assert.IsFalse(result);
         }
 
     }

--- a/BEIMA.Backend.Test/MongoConnectorTest.cs
+++ b/BEIMA.Backend.Test/MongoConnectorTest.cs
@@ -84,12 +84,12 @@ namespace BEIMA.Backend.Test
             };
             var insertResult = mongo.InsertDevice(doc);
             Assert.IsNotNull(insertResult);
-            Assert.IsTrue(insertResult is ObjectId);
+            Assert.That(insertResult, Is.TypeOf(typeof(ObjectId)));
 
             //Test (retrieve the document)
             var retrievedDoc = mongo.GetDevice((ObjectId) doc["_id"]);
             Assert.IsNotNull(retrievedDoc);
-            Assert.IsTrue(retrievedDoc is BsonDocument);
+            Assert.That(retrievedDoc, Is.TypeOf(typeof(BsonDocument)));
         }
 
         [Test]
@@ -103,12 +103,12 @@ namespace BEIMA.Backend.Test
             };
             var insertResult = mongo.InsertDevice(doc);
             Assert.IsNotNull(insertResult);
-            Assert.IsTrue(insertResult is ObjectId);
+            Assert.That(insertResult, Is.TypeOf(typeof(ObjectId)));
 
             //Test (retrieve all documents)
             var retrievedDocs = mongo.GetAllDevices();
             Assert.IsNotNull(retrievedDocs);
-            Assert.IsTrue(retrievedDocs is List<BsonDocument>);
+            Assert.That(retrievedDocs, Is.TypeOf(typeof(List<BsonDocument>)));
         }
 
         [Test]
@@ -122,7 +122,7 @@ namespace BEIMA.Backend.Test
             var result = mongo.InsertDevice(doc);
             Console.WriteLine(result.ToString());
             Assert.IsNotNull(result);
-            Assert.IsTrue(result is ObjectId);
+            Assert.That(result, Is.TypeOf(typeof(ObjectId)));
         }
 
         [Test]
@@ -137,7 +137,7 @@ namespace BEIMA.Backend.Test
             //Insert device
             var insertResult = mongo.InsertDevice(doc);
             Assert.IsNotNull(insertResult);
-            Assert.IsTrue(insertResult is ObjectId);
+            Assert.That(insertResult, Is.TypeOf(typeof(ObjectId)));
 
             //Delete device
             bool deleteResult = false;
@@ -160,7 +160,7 @@ namespace BEIMA.Backend.Test
             //Insert device
             var insertResult = mongo.InsertDevice(doc);
             Assert.IsNotNull(insertResult);
-            Assert.IsTrue(insertResult is ObjectId);
+            Assert.That(insertResult, Is.TypeOf(typeof(ObjectId)));
 
             //Update device
             doc.AddRange(new BsonDocument { { "updatedDeviceField", "123" } });

--- a/BEIMA.Backend.Test/MongoConnectorTest.cs
+++ b/BEIMA.Backend.Test/MongoConnectorTest.cs
@@ -98,20 +98,6 @@ namespace BEIMA.Backend.Test
         }
 
         [Test]
-        public void ConnectorNotCreated_CallConstructorOnce_InstanceConnectedToCorrectEnvironment()
-        {
-            var mongo = MongoConnector.Instance;
-            if (Environment.GetEnvironmentVariable("CurrentEnv") == "dev-local")
-            {
-                Assert.IsTrue(mongo.CurrentServerType == ServerType.Local);
-            }
-            else
-            {
-                Assert.IsTrue(mongo.CurrentServerType == ServerType.Cloud);
-            }
-        }
-
-        [Test]
         public void ConnectorCreated_GetDeviceGivenValidDeviceId_DeviceDocumentReturned()
         {
             var mongo = MongoConnector.Instance;
@@ -240,5 +226,12 @@ namespace BEIMA.Backend.Test
             Assert.IsNull(result);
         }
 
+        [Test]
+        public void ConnectorCreated_CheckIsConnected_TrueReturned()
+        {
+            var mongo = MongoConnector.Instance;
+            var result = mongo.IsConnected();
+            Assert.IsTrue(result);
+        }
     }
 }

--- a/BEIMA.Backend.Test/MongoConnectorTest.cs
+++ b/BEIMA.Backend.Test/MongoConnectorTest.cs
@@ -68,6 +68,7 @@ namespace BEIMA.Backend.Test
         [Test]
         public void ConnectorNotCreated_CallConstructorFiveTimes_FiveInstancesAreEqual()
         {
+            //Tests to make sure singleton is working
             var connector1 = MongoConnector.Instance;
             var connector2 = MongoConnector.Instance;
             var connector3 = MongoConnector.Instance;
@@ -117,7 +118,7 @@ namespace BEIMA.Backend.Test
         public void ConnectorCreated_GetDeviceGivenValidDeviceId_DeviceDocumentReturned()
         {
             var mongo = MongoConnector.Instance;
-            //Test setup
+            //Setup (inserting a document)
             BsonDocument doc = new BsonDocument {
                 { "deviceTypeId", "a" },
                 { "serialNumber", "a12345"}
@@ -126,7 +127,7 @@ namespace BEIMA.Backend.Test
             Assert.IsNotNull(insertResult);
             Assert.IsTrue(insertResult is ObjectId);
 
-            //Test
+            //Test (retrieve the document)
             var retrievedDoc = mongo.GetDevice((ObjectId) doc["_id"]);
             Assert.IsNotNull(retrievedDoc);
             Assert.IsTrue(retrievedDoc is BsonDocument);

--- a/BEIMA.Backend.Test/MongoConnectorTest.cs
+++ b/BEIMA.Backend.Test/MongoConnectorTest.cs
@@ -21,16 +21,24 @@ namespace BEIMA.Backend.Test
         [OneTimeSetUp]
         public void OneTimeSetUp()
         {
-            string[] paths = { "..", "..", "..", "..", "BEIMA.Backend", "local.settings.json" };
-            string combinedPath = Path.Combine(paths);
-            string fullPath = Path.GetFullPath(combinedPath);
-            var settings = JsonConvert.DeserializeObject<LocalSettings>(
-                File.ReadAllText(fullPath));
-
-            foreach (var setting in settings.Values)
+            try
             {
-                Environment.SetEnvironmentVariable(setting.Key, setting.Value);
+                string[] paths = { "..", "..", "..", "..", "BEIMA.Backend", "local.settings.json" };
+                string combinedPath = Path.Combine(paths);
+                string fullPath = Path.GetFullPath(combinedPath);
+                var settings = JsonConvert.DeserializeObject<LocalSettings>(
+                    File.ReadAllText(fullPath));
+
+                foreach (var setting in settings.Values)
+                {
+                    Environment.SetEnvironmentVariable(setting.Key, setting.Value);
+                }
             }
+            catch (Exception ex)
+            {
+                Console.WriteLine(ex.ToString());
+            }
+            
         }
 
         [OneTimeTearDown]

--- a/BEIMA.Backend.Test/MongoConnectorTest.cs
+++ b/BEIMA.Backend.Test/MongoConnectorTest.cs
@@ -1,0 +1,109 @@
+﻿using NUnit.Framework;
+using BEIMA.Backend.MongoService;
+using System.IO;
+using Newtonsoft.Json;
+using System.Collections.Generic;
+using System;
+using MongoDB.Bson;
+
+namespace BEIMA.Backend.Test
+{
+    [TestFixture]
+    public class MongoConnectorTest
+    {
+        //private MongoConnector? mongo;
+        class LocalSettings
+        {
+            public bool IsEncrypted { get; set; }
+            public Dictionary<string, string> Values { get; set; }
+        }
+
+        [OneTimeSetUp]
+        public void OneTimeSetUp()
+        {
+            string basePath = Path.GetFullPath(@"..\..\..\..\BEIMA.Backend");
+            var settings = JsonConvert.DeserializeObject<LocalSettings>(
+                File.ReadAllText(basePath + "\\local.settings.json"));
+
+            foreach (var setting in settings.Values)
+            {
+                Environment.SetEnvironmentVariable(setting.Key, setting.Value);
+            }
+        }
+
+        [OneTimeTearDown]
+        public void OneTimeTearDown()
+        {
+        }
+
+        [SetUp]
+        public void SetUp()
+        {
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+        }
+
+        [Test]
+        public void InitialState_Action_ExpectedResult()
+        {
+            Assert.IsTrue(true);
+        }
+
+        [Test]
+        public void ConnectorNotCreated_CallConstructorFiveTimes_FiveInstancesAreEqual()
+        {
+            var connector1 = MongoConnector.Instance;
+            var connector2 = MongoConnector.Instance;
+            var connector3 = MongoConnector.Instance;
+            var connector4 = MongoConnector.Instance;
+            var connector5 = MongoConnector.Instance;
+            Assert.IsTrue(connector1 == connector2);
+            Assert.IsTrue(connector1 == connector3);
+            Assert.IsTrue(connector1 == connector4);
+            Assert.IsTrue(connector1 == connector5);
+        }
+
+        [Test]
+        public void ConnectorCreated_GetDeviceGivenDeviceId_DeviceDocumentReturned()
+        {
+            var mongo = MongoConnector.Instance;
+            var doc = mongo.GetDevice("61f4882f42dab933544849d3");
+            Assert.IsNotNull(doc);
+            Assert.IsTrue(doc is BsonDocument);
+        }
+
+        [Test]
+        public void ConnectorNotCreated_CallConstructorOnce_InstanceConnectedToCorrectEnvironment()
+        {
+            var mongo = MongoConnector.Instance;
+            if (Environment.GetEnvironmentVariable("CurrentEnv") == "dev-local")
+            {
+                Assert.IsTrue(mongo.CurrentServerType == ServerType.Local);
+            }
+            else
+            {
+                Assert.IsTrue(mongo.CurrentServerType == ServerType.Cloud);
+            }
+        }
+
+        [Test]
+        public void DocumentNotInserted_InsertDocument_DocumentHasBeenInserted()
+        {
+            var mongo = MongoConnector.Instance;
+            BsonDocument doc = new BsonDocument { 
+                { "deviceTypeId", "a" },
+                { "serialNumber", "a12345"}
+            };
+            var result = mongo.InsertDevice(doc);
+            Assert.IsTrue(result);
+        }
+
+
+
+
+
+    }
+}

--- a/BEIMA.Backend.Test/MongoConnectorTest.cs
+++ b/BEIMA.Backend.Test/MongoConnectorTest.cs
@@ -77,12 +77,31 @@ namespace BEIMA.Backend.Test
         }
 
         [Test]
-        public void ConnectorCreated_GetDeviceGivenDeviceId_DeviceDocumentReturned()
+        public void ConnectorCreated_GetDeviceGivenInvalidDeviceId_NullReturned()
         {
             var mongo = MongoConnector.Instance;
+            //This is a valid ObjectId, but this is not in the database
             var doc = mongo.GetDevice(new ObjectId("61f4882f42dab933544849d3"));
-            Assert.IsNotNull(doc);
-            Assert.IsTrue(doc is BsonDocument);
+            Assert.IsNull(doc);
+        }
+
+        [Test]
+        public void ConnectorCreated_GetDeviceGivenValidDeviceId_DeviceDocumentReturned()
+        {
+            var mongo = MongoConnector.Instance;
+            //Test setup
+            BsonDocument doc = new BsonDocument {
+                { "deviceTypeId", "a" },
+                { "serialNumber", "a12345"}
+            };
+            var insertResult = mongo.InsertDevice(doc);
+            Assert.IsNotNull(insertResult);
+            Assert.IsTrue(insertResult is ObjectId);
+
+            //Test
+            var retrievedDoc = mongo.GetDevice((ObjectId) doc["_id"]);
+            Assert.IsNotNull(retrievedDoc);
+            Assert.IsTrue(retrievedDoc is BsonDocument);
         }
 
         [Test]

--- a/BEIMA.Backend.Test/MongoConnectorTest.cs
+++ b/BEIMA.Backend.Test/MongoConnectorTest.cs
@@ -134,6 +134,25 @@ namespace BEIMA.Backend.Test
         }
 
         [Test]
+        public void ConnectorCreated_GetAllDevices_DeviceDocumentListReturned()
+        {
+            var mongo = MongoConnector.Instance;
+            //Setup (inserting a document)
+            BsonDocument doc = new BsonDocument {
+                { "deviceTypeId", "a" },
+                { "serialNumber", "a12345"}
+            };
+            var insertResult = mongo.InsertDevice(doc);
+            Assert.IsNotNull(insertResult);
+            Assert.IsTrue(insertResult is ObjectId);
+
+            //Test (retrieve all documents)
+            var retrievedDocs = mongo.GetAllDevices();
+            Assert.IsNotNull(retrievedDocs);
+            Assert.IsTrue(retrievedDocs is List<BsonDocument>);
+        }
+
+        [Test]
         public void ConnectorNotCreated_CallConstructorOnce_InstanceConnectedToCorrectEnvironment()
         {
             var mongo = MongoConnector.Instance;

--- a/BEIMA.Backend.Test/MongoConnectorTest.cs
+++ b/BEIMA.Backend.Test/MongoConnectorTest.cs
@@ -21,9 +21,11 @@ namespace BEIMA.Backend.Test
         [OneTimeSetUp]
         public void OneTimeSetUp()
         {
-            string basePath = Path.GetFullPath(@"..\..\..\..\BEIMA.Backend");
+            string[] paths = { "..", "..", "..", "..", "BEIMA.Backend" };
+            string combinedPath = Path.Combine(paths);
+            string fullPath = Path.GetFullPath(combinedPath);
             var settings = JsonConvert.DeserializeObject<LocalSettings>(
-                File.ReadAllText(basePath + "\\local.settings.json"));
+                File.ReadAllText(fullPath + "\\local.settings.json"));
 
             foreach (var setting in settings.Values)
             {
@@ -126,7 +128,25 @@ namespace BEIMA.Backend.Test
             Assert.IsTrue(deleteResult);
         }
 
+        [Test]
+        public void DocumentNotInserted_InsertDocumentAndUpdateDocument_DocumentHasBeenUpdated()
+        {
+            var mongo = MongoConnector.Instance;
+            BsonDocument doc = new BsonDocument
+            {
+                { "deviceTypeId", "a" },
+                { "serialNumber", "a12345"}
+            };
+            //Insert device
+            var insertResult = mongo.InsertDevice(doc);
+            Assert.IsNotNull(insertResult);
+            Assert.IsTrue(insertResult is ObjectId);
 
+            //Update device
+            doc.AddRange(new BsonDocument { { "updatedDeviceField", "123" } });
+            var updateResult = mongo.UpdateDevice(doc);
+            Assert.IsTrue(updateResult);
+        }
 
     }
 }

--- a/BEIMA.Backend.Test/MongoConnectorTest.cs
+++ b/BEIMA.Backend.Test/MongoConnectorTest.cs
@@ -21,6 +21,9 @@ namespace BEIMA.Backend.Test
         [OneTimeSetUp]
         public void OneTimeSetUp()
         {
+            //For local testing, the try block will be used to instantiate local variables.
+            //For cloud testing, this will throw an exception, and it will use the env variables
+            //defined in beima.yml.
             try
             {
                 string[] paths = { "..", "..", "..", "..", "BEIMA.Backend", "local.settings.json" };
@@ -83,6 +86,31 @@ namespace BEIMA.Backend.Test
             //This is a valid ObjectId, but this is not in the database
             var doc = mongo.GetDevice(new ObjectId("61f4882f42dab933544849d3"));
             Assert.IsNull(doc);
+        }
+
+        [Test]
+        public void ConnectorCreated_DeleteInvalidObject_FalseReturned()
+        {
+            var mongo = MongoConnector.Instance;
+            //This is a valid ObjectId, but this is not in the database
+            var result = mongo.DeleteDevice(new ObjectId("61f4882f42dab933544849d3"));
+            Assert.IsFalse(result);
+        }
+
+        [Test]
+        public void ConnectorCreated_InsertNull_NullReturned()
+        {
+            var mongo = MongoConnector.Instance;
+            var result = mongo.InsertDevice(null);
+            Assert.IsNull(result);
+        }
+
+        [Test]
+        public void ConnectorCreated_UpdateNull_NullReturned()
+        {
+            var mongo = MongoConnector.Instance;
+            var result = mongo.UpdateDevice(null);
+            Assert.IsFalse(result);
         }
 
         [Test]

--- a/BEIMA.Backend.Test/MongoConnectorTest.cs
+++ b/BEIMA.Backend.Test/MongoConnectorTest.cs
@@ -21,11 +21,11 @@ namespace BEIMA.Backend.Test
         [OneTimeSetUp]
         public void OneTimeSetUp()
         {
-            string[] paths = { "..", "..", "..", "..", "BEIMA.Backend" };
+            string[] paths = { "..", "..", "..", "..", "BEIMA.Backend", "local.settings.json" };
             string combinedPath = Path.Combine(paths);
             string fullPath = Path.GetFullPath(combinedPath);
             var settings = JsonConvert.DeserializeObject<LocalSettings>(
-                File.ReadAllText(fullPath + "\\local.settings.json"));
+                File.ReadAllText(fullPath));
 
             foreach (var setting in settings.Values)
             {

--- a/BEIMA.Backend.Test/MongoConnectorTest.cs
+++ b/BEIMA.Backend.Test/MongoConnectorTest.cs
@@ -165,7 +165,7 @@ namespace BEIMA.Backend.Test
             //Update device
             doc.AddRange(new BsonDocument { { "updatedDeviceField", "123" } });
             var updateResult = mongo.UpdateDevice(doc);
-            Assert.IsTrue(updateResult);
+            Assert.IsNotNull(updateResult);
         }
 
         [Test]
@@ -199,7 +199,7 @@ namespace BEIMA.Backend.Test
         {
             var mongo = MongoConnector.Instance;
             var result = mongo.UpdateDevice(null);
-            Assert.IsFalse(result);
+            Assert.IsNull(result);
         }
 
     }

--- a/BEIMA.Backend.Test/MongoConnectorTest.cs
+++ b/BEIMA.Backend.Test/MongoConnectorTest.cs
@@ -70,7 +70,7 @@ namespace BEIMA.Backend.Test
         public void ConnectorCreated_GetDeviceGivenDeviceId_DeviceDocumentReturned()
         {
             var mongo = MongoConnector.Instance;
-            var doc = mongo.GetDevice("61f4882f42dab933544849d3");
+            var doc = mongo.GetDevice(new ObjectId("61f4882f42dab933544849d3"));
             Assert.IsNotNull(doc);
             Assert.IsTrue(doc is BsonDocument);
         }
@@ -98,10 +98,33 @@ namespace BEIMA.Backend.Test
                 { "serialNumber", "a12345"}
             };
             var result = mongo.InsertDevice(doc);
-            Assert.IsTrue(result);
+            Console.WriteLine(result.ToString());
+            Assert.IsNotNull(result);
+            Assert.IsTrue(result is ObjectId);
         }
 
+        [Test]
+        public void DocumentNotInserted_InsertDocumentAndDeleteDocument_DocumentHasBeenDeleted()
+        {
+            var mongo = MongoConnector.Instance;
+            BsonDocument doc = new BsonDocument
+            {
+                { "deviceTypeId", "a" },
+                { "serialNumber", "a12345"}
+            };
+            //Insert device
+            var insertResult = mongo.InsertDevice(doc);
+            Assert.IsNotNull(insertResult);
+            Assert.IsTrue(insertResult is ObjectId);
 
+            //Delete device
+            bool deleteResult = false;
+            if(insertResult != null)
+            {
+                deleteResult = mongo.DeleteDevice((ObjectId) insertResult);
+            }
+            Assert.IsTrue(deleteResult);
+        }
 
 
 

--- a/BEIMA.Backend.Test/MongoConnectorTest.cs
+++ b/BEIMA.Backend.Test/MongoConnectorTest.cs
@@ -37,7 +37,7 @@ namespace BEIMA.Backend.Test
                     Environment.SetEnvironmentVariable(setting.Key, setting.Value);
                 }
             }
-            catch (DirectoryNotFoundException ex)
+            catch (IOException ex)
             {
                 Console.WriteLine(ex.ToString());
             }

--- a/BEIMA.Backend/MongoService/EnumServerType.cs
+++ b/BEIMA.Backend/MongoService/EnumServerType.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BEIMA.Backend.MongoService
+{
+
+    public enum ServerType
+    {
+        Local,
+        Cloud
+    }
+
+}

--- a/BEIMA.Backend/MongoService/MongoConnector.cs
+++ b/BEIMA.Backend/MongoService/MongoConnector.cs
@@ -46,11 +46,10 @@ namespace BEIMA.Backend.MongoService
             client = new MongoClient(credentials);
         }
 
-        /*
-         * Checks if the client has been instantiated.
-         * Parameter: none
-         * Returns: true if client is not null, false if client is null.
-         */
+        /// <summary>
+        /// Checks if the client has been instantiated.
+        /// </summary>
+        /// <returns>true if client is not null, false if client is null.</returns>
         public bool IsConnected()
         {
             return (client != null);
@@ -64,11 +63,11 @@ namespace BEIMA.Backend.MongoService
             }
         }
 
-        /*
-         * Inserts a device into the "devices" collection
-         * Parameter: BsonDocument that contains the fully formed device document (including all required and optional fields)
-         * Returns: ObjectId of the newly inserted object if successful, null if failed
-         */
+        /// <summary>
+        /// Inserts a device into the "devices" collection
+        /// </summary>
+        /// <param name="doc">BsonDocument that contains the fully formed device document (including all required and optional fields)</param>
+        /// <returns>ObjectId of the newly inserted object if successful, null if failed</returns>
         public ObjectId? InsertDevice(BsonDocument doc)
         {
             CheckIsConnected();
@@ -87,11 +86,11 @@ namespace BEIMA.Backend.MongoService
             }
         }
 
-        /*
-         * Gets a device from the "devices" collection, given an objectID.
-         * Parameter: objectId, corresponds to the "_id" field for a given document inside of MongoDB
-         * Returns: BsonDocument that was requested
-         */
+        /// <summary>
+        /// Gets a device from the "devices" collection, given an objectID.
+        /// </summary>
+        /// <param name="objectId">Corresponds to the "_id" field for a given document inside of MongoDB</param>
+        /// <returns>BsonDocument that was requested</returns>
         public BsonDocument GetDevice(ObjectId objectId)
         {
             CheckIsConnected();
@@ -111,11 +110,10 @@ namespace BEIMA.Backend.MongoService
             }
         }
 
-        /*
-         * Gets a device from the "devices" collection, given an objectID.
-         * Parameter: objectId, corresponds to the "_id" field for a given document inside of MongoDB
-         * Returns: BsonDocument that was requested
-         */
+        /// <summary>
+        /// Gets a device from the "devices" collection, given an objectID.
+        /// </summary>
+        /// <returns>BsonDocument that was requested</returns>
         public List<BsonDocument> GetAllDevices()
         {
             CheckIsConnected();
@@ -136,11 +134,11 @@ namespace BEIMA.Backend.MongoService
             }
         }
 
-        /*
-         * Deletes from the "devices" collection, given the objectID.
-         * Parameter: objectId, corresponds to the "_id" field for a given document inside of MongoDB
-         * Returns: true if successful, false if not successful
-         */
+        /// <summary>
+        /// Deletes from the "devices" collection, given the objectID.
+        /// </summary>
+        /// <param name="objectId">Corresponds to the "_id" field for a given document inside of MongoDB</param>
+        /// <returns>true if successful, false if not successful</returns>
         public bool DeleteDevice(ObjectId objectId)
         {
             CheckIsConnected();
@@ -161,11 +159,11 @@ namespace BEIMA.Backend.MongoService
             }
         }
 
-        /*
-         * Updates a device in the "devices" collection, given a fully formed updated device.
-         * Parameters: BsonDocument containing the updated BsonDocument.
-         * Returns: true if successful, false if unsuccessful
-         */
+        /// <summary>
+        /// Updates a device in the "devices" collection, given a fully formed updated device.
+        /// </summary>
+        /// <param name="doc">BsonDocument containing the updated BsonDocument.</param>
+        /// <returns>true if successful, false if unsuccessful</returns>
         public bool UpdateDevice(BsonDocument doc)
         {
             CheckIsConnected();

--- a/BEIMA.Backend/MongoService/MongoConnector.cs
+++ b/BEIMA.Backend/MongoService/MongoConnector.cs
@@ -8,6 +8,10 @@ using MongoDB.Bson;
 
 namespace BEIMA.Backend.MongoService
 {
+    /// <summary>
+    /// This class abstracts basic CRUD operations for MongoDB. It is implemented as a 
+    /// singleton class, so to instantiate, use this syntax: "var mongo = MongoConnector.Instance;".
+    /// </summary>
     public sealed class MongoConnector
     {
         //Public class members

--- a/BEIMA.Backend/MongoService/MongoConnector.cs
+++ b/BEIMA.Backend/MongoService/MongoConnector.cs
@@ -106,6 +106,34 @@ namespace BEIMA.Backend.MongoService
         }
 
         /*
+         * Gets a device from the "devices" collection, given an objectID.
+         * Parameter: objectId, corresponds to the "_id" field for a given document inside of MongoDB
+         * Returns: BsonDocument that was requested
+         */
+        public List<BsonDocument> GetAllDevices()
+        {
+            if (!IsConnected())
+            {
+                throw new Exception("MongoConnector is not currently connected");
+            }
+
+            var filter = Builders<BsonDocument>.Filter.Empty;
+
+            try
+            {
+                var db = client.GetDatabase(dbName);
+                var devices = db.GetCollection<BsonDocument>(deviceCollection);
+                var docs = devices.Find(filter).ToList();
+                return docs;
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine(ex.Message);
+                return null;
+            }
+        }
+
+        /*
          * Deletes from the "devices" collection, given the objectID.
          * Parameter: objectId, corresponds to the "_id" field for a given document inside of MongoDB
          * Returns: true if successful, false if not successful

--- a/BEIMA.Backend/MongoService/MongoConnector.cs
+++ b/BEIMA.Backend/MongoService/MongoConnector.cs
@@ -164,7 +164,7 @@ namespace BEIMA.Backend.MongoService
         /// </summary>
         /// <param name="doc">BsonDocument containing the updated BsonDocument.</param>
         /// <returns>true if successful, false if unsuccessful</returns>
-        public bool UpdateDevice(BsonDocument doc)
+        public BsonDocument UpdateDevice(BsonDocument doc)
         {
             CheckIsConnected();
 
@@ -175,12 +175,19 @@ namespace BEIMA.Backend.MongoService
                 var db = client.GetDatabase(dbName);
                 var devices = db.GetCollection<BsonDocument>(deviceCollection);
                 var result = devices.ReplaceOne(filter, doc);
-                return result.ModifiedCount > 0;
+                if (result.ModifiedCount > 0)
+                {
+                    return doc;
+                }
+                else
+                {
+                    return null;
+                }
             }
             catch (Exception ex)
             {
                 Console.Error.WriteLine(ex.Message);
-                return false;
+                return null;
             }
         }
     }

--- a/BEIMA.Backend/MongoService/MongoConnector.cs
+++ b/BEIMA.Backend/MongoService/MongoConnector.cs
@@ -52,6 +52,14 @@ namespace BEIMA.Backend.MongoService
             return (client != null);
         }
 
+        private void CheckIsConnected()
+        {
+            if (!IsConnected())
+            {
+                throw new Exception("MongoConnector is not currently connected");
+            }
+        }
+
         /*
          * Inserts a device into the "devices" collection
          * Parameter: BsonDocument that contains the fully formed device document (including all required and optional fields)
@@ -59,10 +67,7 @@ namespace BEIMA.Backend.MongoService
          */
         public ObjectId? InsertDevice(BsonDocument doc)
         {
-            if (!IsConnected())
-            {
-                throw new Exception("MongoConnector is not currently connected");
-            }
+            CheckIsConnected();
 
             try
             {
@@ -85,10 +90,7 @@ namespace BEIMA.Backend.MongoService
          */
         public BsonDocument GetDevice(ObjectId objectId)
         {
-            if (!IsConnected())
-            {
-                throw new Exception("MongoConnector is not currently connected");
-            }
+            CheckIsConnected();
 
             var filter = Builders<BsonDocument>.Filter.Eq("_id", objectId);
 
@@ -112,10 +114,7 @@ namespace BEIMA.Backend.MongoService
          */
         public List<BsonDocument> GetAllDevices()
         {
-            if (!IsConnected())
-            {
-                throw new Exception("MongoConnector is not currently connected");
-            }
+            CheckIsConnected();
 
             var filter = Builders<BsonDocument>.Filter.Empty;
 
@@ -140,10 +139,7 @@ namespace BEIMA.Backend.MongoService
          */
         public bool DeleteDevice(ObjectId objectId)
         {
-            if (!IsConnected())
-            {
-                throw new Exception("MongoConnector is not currently connected");
-            }
+            CheckIsConnected();
 
             var filter = Builders<BsonDocument>.Filter.Eq("_id", objectId);
 
@@ -168,10 +164,7 @@ namespace BEIMA.Backend.MongoService
          */
         public bool UpdateDevice(BsonDocument doc)
         {
-            if (!IsConnected())
-            {
-                throw new Exception("MongoConnector is not currently connected");
-            }
+            CheckIsConnected();
 
             try
             {

--- a/BEIMA.Backend/MongoService/MongoConnector.cs
+++ b/BEIMA.Backend/MongoService/MongoConnector.cs
@@ -55,7 +55,7 @@ namespace BEIMA.Backend.MongoService
         /*
          * Inserts a device into the "devices" collection
          * Parameter: BsonDocument that contains the fully formed device document (including all required and optional fields)
-         * Returns: true if success, false if failed
+         * Returns: ObjectId of the newly inserted object if successful, null if failed
          */
         public ObjectId? InsertDevice(BsonDocument doc)
         {
@@ -124,7 +124,7 @@ namespace BEIMA.Backend.MongoService
                 var db = client.GetDatabase(dbName);
                 var devices = db.GetCollection<BsonDocument>(deviceCollection);
                 var result = devices.DeleteOne(filter);
-                return result.IsAcknowledged;
+                return result.DeletedCount > 0;
             }
             catch (Exception ex)
             {
@@ -145,15 +145,14 @@ namespace BEIMA.Backend.MongoService
                 throw new Exception("MongoConnector is not currently connected");
             }
 
-            ObjectId objectId = (ObjectId)doc["_id"];
-            var filter = Builders<BsonDocument>.Filter.Eq("_id", objectId);
-
             try
             {
+                ObjectId objectId = (ObjectId)doc["_id"];
+                var filter = Builders<BsonDocument>.Filter.Eq("_id", objectId);
                 var db = client.GetDatabase(dbName);
                 var devices = db.GetCollection<BsonDocument>(deviceCollection);
                 var result = devices.ReplaceOne(filter, doc);
-                return result.IsAcknowledged;
+                return result.ModifiedCount > 0;
             }
             catch (Exception ex)
             {

--- a/BEIMA.Backend/MongoService/MongoConnector.cs
+++ b/BEIMA.Backend/MongoService/MongoConnector.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using MongoDB.Driver;
+using MongoDB.Bson;
+
+namespace MongoService
+{
+    public sealed class MongoConnector
+    {
+        private readonly MongoClient client = null;
+        private static MongoConnector instance = null;
+        private readonly string dbName = Environment.GetEnvironmentVariable("DatabaseName");
+        private readonly string deviceCollection = Environment.GetEnvironmentVariable("DeviceCollectionName");
+
+        //Private constructor, used for singleton pattern
+        private MongoConnector() {
+
+            string credentials;
+
+            //TODO: implement check to see if using local or cloud database
+            if (Environment.GetEnvironmentVariable("CurrentEnv") == "dev-local")
+            {
+                credentials = Environment.GetEnvironmentVariable("LocalMongoConnection");
+            } 
+            else
+            {
+                credentials = Environment.GetEnvironmentVariable("AzureCosmosConnection");
+            }
+            client = new MongoClient(credentials);
+        }
+        
+        //Singleton design pattern
+        public static MongoConnector Instance
+        {
+            get { return instance ??= new MongoConnector(); }
+        }
+
+        
+    }
+}

--- a/BEIMA.Backend/MongoService/MongoConnector.cs
+++ b/BEIMA.Backend/MongoService/MongoConnector.cs
@@ -10,19 +10,25 @@ namespace BEIMA.Backend.MongoService
 {
     public sealed class MongoConnector
     {
+        //Public class members
         public ServerType CurrentServerType { get; }
 
-        private MongoClient client = null;
-        private static MongoConnector instance = null;
+        //Contains instance variables
+        private readonly MongoClient client = null;
+        private static readonly Lazy<MongoConnector> instance = new(() => new MongoConnector());
+
+        //Environment variables
         private readonly string dbName = Environment.GetEnvironmentVariable("DatabaseName");
         private readonly string deviceCollection = Environment.GetEnvironmentVariable("DeviceCollectionName");
 
-        //Private constructor, used for singleton pattern
+        //Singleton design pattern, used to get an instance of the MongoConnector
+        public static MongoConnector Instance { get { return instance.Value; } }
+
+        //Private constructor, used for singleton pattern. Cannot be called externally.
         private MongoConnector()
         {
             string credentials;
 
-            //TODO: implement check to see if using local or cloud database
             if (Environment.GetEnvironmentVariable("CurrentEnv") == "dev-local")
             {
                 CurrentServerType = ServerType.Local;
@@ -34,12 +40,6 @@ namespace BEIMA.Backend.MongoService
                 credentials = Environment.GetEnvironmentVariable("AzureCosmosConnection");
             }
             client = new MongoClient(credentials);
-        }
-
-        //Singleton design pattern
-        public static MongoConnector Instance
-        {
-            get { return instance ??= new MongoConnector(); }
         }
 
         /*

--- a/BEIMA.Backend/MongoService/MongoConnector.cs
+++ b/BEIMA.Backend/MongoService/MongoConnector.cs
@@ -57,7 +57,7 @@ namespace BEIMA.Backend.MongoService
          * Parameter: BsonDocument that contains the fully formed device document (including all required and optional fields)
          * Returns: true if success, false if failed
          */
-        public bool InsertDevice(BsonDocument doc)
+        public ObjectId? InsertDevice(BsonDocument doc)
         {
             if (!IsConnected())
             {
@@ -69,12 +69,12 @@ namespace BEIMA.Backend.MongoService
                 var db = client.GetDatabase(dbName);
                 var devices = db.GetCollection<BsonDocument>(deviceCollection);
                 devices.InsertOne(doc);
-                return true;
+                return (ObjectId) doc["_id"];
             }
             catch (Exception ex)
             {
                 Console.Error.WriteLine(ex.Message);
-                return false;
+                return null;
             }
         }
 
@@ -83,14 +83,13 @@ namespace BEIMA.Backend.MongoService
          * Parameter: objectId, corresponds to the "_id" field for a given document inside of MongoDB
          * Returns: BsonDocument that was requested
          */
-        public BsonDocument GetDevice(string objectIdString)
+        public BsonDocument GetDevice(ObjectId objectId)
         {
             if (!IsConnected())
             {
                 throw new Exception("MongoConnector is not currently connected");
             }
 
-            var objectId = new ObjectId(objectIdString);
             var filter = Builders<BsonDocument>.Filter.Eq("_id", objectId);
 
             try
@@ -111,14 +110,13 @@ namespace BEIMA.Backend.MongoService
          * Parameter: objectId, corresponds to the "_id" field for a given document inside of MongoDB
          * Returns: true if successful, false if not successful
          */
-        public bool DeleteDevice(string objectIdString)
+        public bool DeleteDevice(ObjectId objectId)
         {
             if (!IsConnected())
             {
                 throw new Exception("MongoConnector is not currently connected");
             }
 
-            var objectId = new ObjectId(objectIdString);
             var filter = Builders<BsonDocument>.Filter.Eq("_id", objectId);
 
             try

--- a/BEIMA.Backend/MongoService/MongoConnector.cs
+++ b/BEIMA.Backend/MongoService/MongoConnector.cs
@@ -6,38 +6,162 @@ using System.Threading.Tasks;
 using MongoDB.Driver;
 using MongoDB.Bson;
 
-namespace MongoService
+namespace BEIMA.Backend.MongoService
 {
     public sealed class MongoConnector
     {
-        private readonly MongoClient client = null;
+        public ServerType CurrentServerType { get; }
+
+        private MongoClient client = null;
         private static MongoConnector instance = null;
         private readonly string dbName = Environment.GetEnvironmentVariable("DatabaseName");
         private readonly string deviceCollection = Environment.GetEnvironmentVariable("DeviceCollectionName");
 
         //Private constructor, used for singleton pattern
-        private MongoConnector() {
-
+        private MongoConnector()
+        {
             string credentials;
 
             //TODO: implement check to see if using local or cloud database
             if (Environment.GetEnvironmentVariable("CurrentEnv") == "dev-local")
             {
+                CurrentServerType = ServerType.Local;
                 credentials = Environment.GetEnvironmentVariable("LocalMongoConnection");
-            } 
+            }
             else
             {
+                CurrentServerType = ServerType.Cloud;
                 credentials = Environment.GetEnvironmentVariable("AzureCosmosConnection");
             }
             client = new MongoClient(credentials);
         }
-        
+
         //Singleton design pattern
         public static MongoConnector Instance
         {
             get { return instance ??= new MongoConnector(); }
         }
 
-        
+        /*
+         * Checks if the client has been instantiated.
+         * Parameter: none
+         * Returns: true if client is not null, false if client is null.
+         */
+        public bool IsConnected()
+        {
+            return (client != null);
+        }
+
+        /*
+         * Inserts a device into the "devices" collection
+         * Parameter: BsonDocument that contains the fully formed device document (including all required and optional fields)
+         * Returns: true if success, false if failed
+         */
+        public bool InsertDevice(BsonDocument doc)
+        {
+            if (!IsConnected())
+            {
+                throw new Exception("MongoConnector is not currently connected");
+            }
+
+            try
+            {
+                var db = client.GetDatabase(dbName);
+                var devices = db.GetCollection<BsonDocument>(deviceCollection);
+                devices.InsertOne(doc);
+                return true;
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine(ex.Message);
+                return false;
+            }
+        }
+
+        /*
+         * Gets a device from the "devices" collection, given an objectID.
+         * Parameter: objectId, corresponds to the "_id" field for a given document inside of MongoDB
+         * Returns: BsonDocument that was requested
+         */
+        public BsonDocument GetDevice(string objectIdString)
+        {
+            if (!IsConnected())
+            {
+                throw new Exception("MongoConnector is not currently connected");
+            }
+
+            var objectId = new ObjectId(objectIdString);
+            var filter = Builders<BsonDocument>.Filter.Eq("_id", objectId);
+
+            try
+            {
+                var db = client.GetDatabase(dbName);
+                var devices = db.GetCollection<BsonDocument>(deviceCollection);
+                return devices.Find(filter).FirstOrDefault();
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine(ex.Message);
+                return null;
+            }
+        }
+
+        /*
+         * Deletes from the "devices" collection, given the objectID.
+         * Parameter: objectId, corresponds to the "_id" field for a given document inside of MongoDB
+         * Returns: true if successful, false if not successful
+         */
+        public bool DeleteDevice(string objectIdString)
+        {
+            if (!IsConnected())
+            {
+                throw new Exception("MongoConnector is not currently connected");
+            }
+
+            var objectId = new ObjectId(objectIdString);
+            var filter = Builders<BsonDocument>.Filter.Eq("_id", objectId);
+
+            try
+            {
+                var db = client.GetDatabase(dbName);
+                var devices = db.GetCollection<BsonDocument>(deviceCollection);
+                var result = devices.DeleteOne(filter);
+                return result.IsAcknowledged;
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine(ex.Message);
+                return false;
+            }
+        }
+
+        /*
+         * Updates a device in the "devices" collection, given a fully formed updated device.
+         * Parameters: BsonDocument containing the updated BsonDocument.
+         * Returns: true if successful, false if unsuccessful
+         */
+        public bool UpdateDevice(BsonDocument doc)
+        {
+            if (!IsConnected())
+            {
+                throw new Exception("MongoConnector is not currently connected");
+            }
+
+            ObjectId objectId = (ObjectId)doc["_id"];
+            var filter = Builders<BsonDocument>.Filter.Eq("_id", objectId);
+
+            try
+            {
+                var db = client.GetDatabase(dbName);
+                var devices = db.GetCollection<BsonDocument>(deviceCollection);
+                var result = devices.ReplaceOne(filter, doc);
+                return result.IsAcknowledged;
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine(ex.Message);
+                return false;
+            }
+        }
     }
 }


### PR DESCRIPTION
<!--
These comments inside these brackets will not appear in the pull request.

The pull request should be linked to either:
 - a task (i.e., use 'Closes #TaskID' or 'Resolves #TaskID')
 - a bug (i.e., use 'Closes #BugID' or 'Fixes #BugID')

For more details, see: https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes #23 - story
Closes #24 
Closes #26
Closes #27 
Closes #29 
Closes #60

This PR implements the MongoConnector. It abstracts out the basic CRUD operations we need for the "devices" collection. The purpose of this connector is only to abstract the calls to the MongoDB.Driver itself. In our endpoints, we still need to form the documents there; this connector will serve to accept those documents and perform those operations.

This story only concerns the "devices" collection. The "users" and "device-types" collections are not in this story's scope.

This PR also contains unit tests for the MongoConnector. All tests have passed on my local machine, and using the beima.yml GitHub Action.

I am aware this is a large pull request, but since all of this work is closely related, is an initial implementation, and builds on each other, it is difficult and highly time consuming to get these separated out into smaller PRs.
