### PR TITLE
Implemented DeviceType Functionality in MongoConnector

### DIFF
--- a/.github/workflows/beima.yml
+++ b/.github/workflows/beima.yml
@@ -17,6 +17,7 @@ env:
   DatabaseName: beima
   DeviceCollectionName: devices
   AzureCosmosConnection: ${{ secrets.AZURE_COSMOS_CONNECTION }}
+  DeviceTypeCollectionName: deviceTypes
 
 jobs:
   build:

--- a/BEIMA.Backend.Test/MongoService/MongoConnectorTest.cs
+++ b/BEIMA.Backend.Test/MongoService/MongoConnectorTest.cs
@@ -160,5 +160,121 @@ namespace BEIMA.Backend.Test.MongoService
             var result = mongo.IsConnected();
             Assert.IsTrue(result);
         }
+
+        //DeviceType tests
+
+        [Test]
+        public void ConnectorCreated_GetDeviceTypeGivenValidDeviceTypeId_DeviceDocumentReturned()
+        {
+            var mongo = MongoConnector.Instance;
+            //Setup (inserting a document)
+            var doc = new BsonDocument {
+                { "name", "TestDeviceType"},
+                { "description", "This is a test" }
+            };
+            var insertResult = mongo.InsertDeviceType(doc);
+            Assert.IsNotNull(insertResult);
+            Assert.That(insertResult, Is.TypeOf(typeof(ObjectId)));
+
+            //Test (retrieve the document)
+            var retrievedDoc = mongo.GetDeviceType((ObjectId)doc["_id"]);
+            Assert.IsNotNull(retrievedDoc);
+            Assert.That(retrievedDoc, Is.TypeOf(typeof(BsonDocument)));
+        }
+
+        [Test]
+        public void ConnectorCreated_GetAllDeviceTypes_DeviceDocumentListReturned()
+        {
+            var mongo = MongoConnector.Instance;
+            //Setup (inserting a document)
+            var doc = new BsonDocument {
+                { "name", "TestDeviceType"},
+                { "description", "This is a test" }
+            };
+            var insertResult = mongo.InsertDeviceType(doc);
+            Assert.IsNotNull(insertResult);
+            Assert.That(insertResult, Is.TypeOf(typeof(ObjectId)));
+
+            //Test (retrieve all documents)
+            var retrievedDocs = mongo.GetAllDeviceTypes();
+            Assert.IsNotNull(retrievedDocs);
+            Assert.That(retrievedDocs, Is.TypeOf(typeof(List<BsonDocument>)));
+        }
+
+        [Test]
+        public void DeviceTypeNotInserted_InsertDeviceTypeAndDeleteDeviceType_DeviceTypeHasBeenDeleted()
+        {
+            var mongo = MongoConnector.Instance;
+            var doc = new BsonDocument {
+                { "name", "TestDeviceType"},
+                { "description", "This is a test" }
+            };
+            //Insert device type
+            var insertResult = mongo.InsertDeviceType(doc);
+            Assert.IsNotNull(insertResult);
+            Assert.That(insertResult, Is.TypeOf(typeof(ObjectId)));
+
+            //Delete device type
+            bool deleteResult = false;
+            if (insertResult != null)
+            {
+                deleteResult = mongo.DeleteDeviceType((ObjectId)insertResult);
+                Assert.IsNull(mongo.GetDeviceType((ObjectId)insertResult));
+            }
+            Assert.IsTrue(deleteResult);
+        }
+
+        [Test]
+        public void DeviceTypeNotInserted_InsertDeviceTypeAndUpdateDeviceType_DeviceTypeHasBeenUpdated()
+        {
+            var mongo = MongoConnector.Instance;
+            var doc = new BsonDocument {
+                { "name", "TestDeviceType"},
+                { "description", "This is a test" }
+            };
+            //Insert device type
+            var insertResult = mongo.InsertDeviceType(doc);
+            Assert.IsNotNull(insertResult);
+            Assert.That(insertResult, Is.TypeOf(typeof(ObjectId)));
+
+            //Update device type
+            doc.AddRange(new BsonDocument { { "updatedDeviceTypeField", "123" } });
+            var updateResult = mongo.UpdateDeviceType(doc);
+            Assert.IsNotNull(updateResult);
+        }
+
+        [Test]
+        public void ConnectorCreated_GetDeviceTypeGivenInvalidDeviceTypeId_NullReturned()
+        {
+            var mongo = MongoConnector.Instance;
+            //This is a valid ObjectId, but this is not in the database
+            var doc = mongo.GetDeviceType(ObjectId.GenerateNewId());
+            Assert.IsNull(doc);
+        }
+
+        [Test]
+        public void ConnectorCreated_DeleteInvalidDeviceType_FalseReturned()
+        {
+            var mongo = MongoConnector.Instance;
+            //This is a valid ObjectId, but this is not in the database
+            var result = mongo.DeleteDeviceType(ObjectId.GenerateNewId());
+            Assert.IsFalse(result);
+        }
+
+        [Test]
+        public void ConnectorCreated_InsertNullDeviceType_NullReturned()
+        {
+            var mongo = MongoConnector.Instance;
+            var result = mongo.InsertDeviceType(null);
+            Assert.IsNull(result);
+        }
+
+        [Test]
+        public void ConnectorCreated_UpdateNullDeviceType_NullReturned()
+        {
+            var mongo = MongoConnector.Instance;
+            var result = mongo.UpdateDeviceType(null);
+            Assert.IsNull(result);
+        }
     }
 }

--- a/BEIMA.Backend.Test/MongoService/MongoConnectorTest.cs
+++ b/BEIMA.Backend.Test/MongoService/MongoConnectorTest.cs
@@ -9,6 +9,7 @@ namespace BEIMA.Backend.Test.MongoService
     [TestFixture]
     public class MongoConnectorTest : UnitTestBase
     {
+        #region Class Tests
         [Test]
         public void ConnectorNotCreated_CallConstructorFiveTimes_FiveInstancesAreEqual()
         {
@@ -25,6 +26,16 @@ namespace BEIMA.Backend.Test.MongoService
         }
 
         [Test]
+        public void ConnectorCreated_CheckIsConnected_TrueReturned()
+        {
+            var mongo = MongoConnector.Instance;
+            var result = mongo.IsConnected();
+            Assert.IsTrue(result);
+        }
+        #endregion
+
+        #region Device Tests
+        [Test]
         public void ConnectorCreated_GetDeviceGivenValidDeviceId_DeviceDocumentReturned()
         {
             var mongo = MongoConnector.Instance;
@@ -34,8 +45,8 @@ namespace BEIMA.Backend.Test.MongoService
                 { "serialNumber", "a12345"}
             };
             var insertResult = mongo.InsertDevice(doc);
-            Assert.IsNotNull(insertResult);
-            Assert.That(insertResult, Is.TypeOf(typeof(ObjectId)));
+            Assume.That(insertResult, Is.Not.Null);
+            Assume.That(insertResult, Is.TypeOf(typeof(ObjectId)));
 
             //Test (retrieve the document)
             var retrievedDoc = mongo.GetDevice((ObjectId)doc["_id"]);
@@ -53,8 +64,8 @@ namespace BEIMA.Backend.Test.MongoService
                 { "serialNumber", "a12345"}
             };
             var insertResult = mongo.InsertDevice(doc);
-            Assert.IsNotNull(insertResult);
-            Assert.That(insertResult, Is.TypeOf(typeof(ObjectId)));
+            Assume.That(insertResult, Is.Not.Null);
+            Assume.That(insertResult, Is.TypeOf(typeof(ObjectId)));
 
             //Test (retrieve all documents)
             var retrievedDocs = mongo.GetAllDevices();
@@ -66,29 +77,28 @@ namespace BEIMA.Backend.Test.MongoService
         public void DeviceNotInserted_InsertDevice_DeviceHasBeenInserted()
         {
             var mongo = MongoConnector.Instance;
-            BsonDocument doc = new BsonDocument {
+            var doc = new BsonDocument {
                 { "deviceTypeId", "a" },
                 { "serialNumber", "a12345"}
             };
             var result = mongo.InsertDevice(doc);
-            Console.WriteLine(result.ToString());
             Assert.IsNotNull(result);
             Assert.That(result, Is.TypeOf(typeof(ObjectId)));
         }
 
         [Test]
-        public void DeviceNotInserted_InsertDeviceAndDeleteDevice_DeviceHasBeenDeleted()
+        public void InsertDevice_DeleteDevice_DeviceHasBeenDeleted()
         {
             var mongo = MongoConnector.Instance;
-            BsonDocument doc = new BsonDocument
+            var doc = new BsonDocument
             {
                 { "deviceTypeId", "a" },
                 { "serialNumber", "a12345"}
             };
             //Insert device
             var insertResult = mongo.InsertDevice(doc);
-            Assert.IsNotNull(insertResult);
-            Assert.That(insertResult, Is.TypeOf(typeof(ObjectId)));
+            Assume.That(insertResult, Is.Not.Null);
+            Assume.That(insertResult, Is.TypeOf(typeof(ObjectId)));
 
             //Delete device
             bool deleteResult = false;
@@ -100,18 +110,18 @@ namespace BEIMA.Backend.Test.MongoService
         }
 
         [Test]
-        public void DeviceNotInserted_InsertDeviceAndUpdateDevice_DeviceHasBeenUpdated()
+        public void InsertDevice_UpdateDevice_DeviceHasBeenUpdated()
         {
             var mongo = MongoConnector.Instance;
-            BsonDocument doc = new BsonDocument
+            var doc = new BsonDocument
             {
                 { "deviceTypeId", "a" },
                 { "serialNumber", "a12345"}
             };
             //Insert device
             var insertResult = mongo.InsertDevice(doc);
-            Assert.IsNotNull(insertResult);
-            Assert.That(insertResult, Is.TypeOf(typeof(ObjectId)));
+            Assume.That(insertResult, Is.Not.Null);
+            Assume.That(insertResult, Is.TypeOf(typeof(ObjectId)));
 
             //Update device
             doc.AddRange(new BsonDocument { { "updatedDeviceField", "123" } });
@@ -153,15 +163,9 @@ namespace BEIMA.Backend.Test.MongoService
             Assert.IsNull(result);
         }
 
-        [Test]
-        public void ConnectorCreated_CheckIsConnected_TrueReturned()
-        {
-            var mongo = MongoConnector.Instance;
-            var result = mongo.IsConnected();
-            Assert.IsTrue(result);
-        }
+        #endregion
 
-        //DeviceType tests
+        #region DeviceType Tests
 
         [Test]
         public void ConnectorCreated_GetDeviceTypeGivenValidDeviceTypeId_DeviceDocumentReturned()
@@ -173,8 +177,8 @@ namespace BEIMA.Backend.Test.MongoService
                 { "description", "This is a test" }
             };
             var insertResult = mongo.InsertDeviceType(doc);
-            Assert.IsNotNull(insertResult);
-            Assert.That(insertResult, Is.TypeOf(typeof(ObjectId)));
+            Assume.That(insertResult, Is.Not.Null);
+            Assume.That(insertResult, Is.TypeOf(typeof(ObjectId)));
 
             //Test (retrieve the document)
             var retrievedDoc = mongo.GetDeviceType((ObjectId)doc["_id"]);
@@ -192,8 +196,8 @@ namespace BEIMA.Backend.Test.MongoService
                 { "description", "This is a test" }
             };
             var insertResult = mongo.InsertDeviceType(doc);
-            Assert.IsNotNull(insertResult);
-            Assert.That(insertResult, Is.TypeOf(typeof(ObjectId)));
+            Assume.That(insertResult, Is.Not.Null);
+            Assume.That(insertResult, Is.TypeOf(typeof(ObjectId)));
 
             //Test (retrieve all documents)
             var retrievedDocs = mongo.GetAllDeviceTypes();
@@ -202,7 +206,7 @@ namespace BEIMA.Backend.Test.MongoService
         }
 
         [Test]
-        public void DeviceTypeNotInserted_InsertDeviceTypeAndDeleteDeviceType_DeviceTypeHasBeenDeleted()
+        public void InsertDeviceType_DeleteDeviceType_DeviceTypeHasBeenDeleted()
         {
             var mongo = MongoConnector.Instance;
             var doc = new BsonDocument {
@@ -211,8 +215,8 @@ namespace BEIMA.Backend.Test.MongoService
             };
             //Insert device type
             var insertResult = mongo.InsertDeviceType(doc);
-            Assert.IsNotNull(insertResult);
-            Assert.That(insertResult, Is.TypeOf(typeof(ObjectId)));
+            Assume.That(insertResult, Is.Not.Null);
+            Assume.That(insertResult, Is.TypeOf(typeof(ObjectId)));
 
             //Delete device type
             bool deleteResult = false;
@@ -225,7 +229,7 @@ namespace BEIMA.Backend.Test.MongoService
         }
 
         [Test]
-        public void DeviceTypeNotInserted_InsertDeviceTypeAndUpdateDeviceType_DeviceTypeHasBeenUpdated()
+        public void InsertDeviceType_UpdateDeviceType_DeviceTypeHasBeenUpdated()
         {
             var mongo = MongoConnector.Instance;
             var doc = new BsonDocument {
@@ -234,8 +238,8 @@ namespace BEIMA.Backend.Test.MongoService
             };
             //Insert device type
             var insertResult = mongo.InsertDeviceType(doc);
-            Assert.IsNotNull(insertResult);
-            Assert.That(insertResult, Is.TypeOf(typeof(ObjectId)));
+            Assume.That(insertResult, Is.Not.Null);
+            Assume.That(insertResult, Is.TypeOf(typeof(ObjectId)));
 
             //Update device type
             doc.AddRange(new BsonDocument { { "updatedDeviceTypeField", "123" } });
@@ -276,5 +280,6 @@ namespace BEIMA.Backend.Test.MongoService
             var result = mongo.UpdateDeviceType(null);
             Assert.IsNull(result);
         }
+        #endregion
     }
 }

--- a/BEIMA.Backend.Test/MongoService/MongoConnectorTest.cs
+++ b/BEIMA.Backend.Test/MongoService/MongoConnectorTest.cs
@@ -63,7 +63,7 @@ namespace BEIMA.Backend.Test.MongoService
         }
 
         [Test]
-        public void DocumentNotInserted_InsertDocument_DocumentHasBeenInserted()
+        public void DeviceNotInserted_InsertDevice_DeviceHasBeenInserted()
         {
             var mongo = MongoConnector.Instance;
             BsonDocument doc = new BsonDocument {
@@ -77,7 +77,7 @@ namespace BEIMA.Backend.Test.MongoService
         }
 
         [Test]
-        public void DocumentNotInserted_InsertDocumentAndDeleteDocument_DocumentHasBeenDeleted()
+        public void DeviceNotInserted_InsertDeviceAndDeleteDevice_DeviceHasBeenDeleted()
         {
             var mongo = MongoConnector.Instance;
             BsonDocument doc = new BsonDocument
@@ -100,7 +100,7 @@ namespace BEIMA.Backend.Test.MongoService
         }
 
         [Test]
-        public void DocumentNotInserted_InsertDocumentAndUpdateDocument_DocumentHasBeenUpdated()
+        public void DeviceNotInserted_InsertDeviceAndUpdateDevice_DeviceHasBeenUpdated()
         {
             var mongo = MongoConnector.Instance;
             BsonDocument doc = new BsonDocument
@@ -129,7 +129,7 @@ namespace BEIMA.Backend.Test.MongoService
         }
 
         [Test]
-        public void ConnectorCreated_DeleteInvalidObject_FalseReturned()
+        public void ConnectorCreated_DeleteInvalidDevice_FalseReturned()
         {
             var mongo = MongoConnector.Instance;
             //This is a valid ObjectId, but this is not in the database
@@ -138,7 +138,7 @@ namespace BEIMA.Backend.Test.MongoService
         }
 
         [Test]
-        public void ConnectorCreated_InsertNull_NullReturned()
+        public void ConnectorCreated_InsertNullDevice_NullReturned()
         {
             var mongo = MongoConnector.Instance;
             var result = mongo.InsertDevice(null);
@@ -146,7 +146,7 @@ namespace BEIMA.Backend.Test.MongoService
         }
 
         [Test]
-        public void ConnectorCreated_UpdateNull_NullReturned()
+        public void ConnectorCreated_UpdateNullDevice_NullReturned()
         {
             var mongo = MongoConnector.Instance;
             var result = mongo.UpdateDevice(null);
@@ -183,7 +183,7 @@ namespace BEIMA.Backend.Test.MongoService
         }
 
         [Test]
-        public void ConnectorCreated_GetAllDeviceTypes_DeviceDocumentListReturned()
+        public void ConnectorCreated_GetAllDeviceTypes_DeviceTypeDocumentListReturned()
         {
             var mongo = MongoConnector.Instance;
             //Setup (inserting a document)

--- a/BEIMA.Backend.Test/UnitTestBase.cs
+++ b/BEIMA.Backend.Test/UnitTestBase.cs
@@ -9,8 +9,8 @@ namespace BEIMA.Backend.Test
 {
     public class UnitTestBase
     {
-        private string? dbName;
-        private string? devicesName;
+        private static string? dbName;
+        private static string? devicesName;
 
         class LocalSettings
         {
@@ -46,8 +46,12 @@ namespace BEIMA.Backend.Test
                 Console.WriteLine(ex.ToString());
             }
 
-            dbName = "beima-test" + Guid.NewGuid().ToString();
-            devicesName = "devices-test" + Guid.NewGuid().ToString();
+            // Prevents the environment variable getting changed when running multiple test classes at the same time
+            if(dbName == null && devicesName == null)
+            {
+                dbName = "beima-test" + Guid.NewGuid().ToString();
+                devicesName = "devices-test" + Guid.NewGuid().ToString();
+            }
 
             Environment.SetEnvironmentVariable("DatabaseName", dbName);
             Environment.SetEnvironmentVariable("DeviceCollectionName", devicesName);

--- a/BEIMA.Backend.Test/UnitTestBase.cs
+++ b/BEIMA.Backend.Test/UnitTestBase.cs
@@ -46,7 +46,7 @@ namespace BEIMA.Backend.Test
                 Console.WriteLine(ex.ToString());
             }
 
-            // Prevents the environment variable getting changed when running multiple test classes at the same time 
+            // Prevents the environment variable getting changed when running multiple test classes at the same time
             if(dbName == null && devicesName == null)
             {
                 dbName = "beima-test" + Guid.NewGuid().ToString();

--- a/BEIMA.Backend.Test/UnitTestBase.cs
+++ b/BEIMA.Backend.Test/UnitTestBase.cs
@@ -46,7 +46,7 @@ namespace BEIMA.Backend.Test
                 Console.WriteLine(ex.ToString());
             }
 
-            // Prevents the environment variable getting changed when running multiple test classes at the same time
+            // Prevents the environment variable getting changed when running multiple test classes at the same time 
             if(dbName == null && devicesName == null)
             {
                 dbName = "beima-test" + Guid.NewGuid().ToString();

--- a/BEIMA.Backend/MongoService/MongoConnector.cs
+++ b/BEIMA.Backend/MongoService/MongoConnector.cs
@@ -54,6 +54,10 @@ namespace BEIMA.Backend.MongoService
             return (client != null);
         }
 
+        /// <summary>
+        /// Private internal method for checking if mongo is connected, will throw an exception if it is not connected.
+        /// </summary>
+        /// <exception cref="Exception">Throws exception if Mongo client is not connected.</exception>
         private void CheckIsConnected()
         {
             if (!IsConnected())
@@ -62,6 +66,7 @@ namespace BEIMA.Backend.MongoService
             }
         }
 
+        #region Device Methods
         /// <summary>
         /// Inserts a device into the "devices" collection
         /// </summary>
@@ -189,7 +194,9 @@ namespace BEIMA.Backend.MongoService
                 return null;
             }
         }
+        #endregion
 
+        #region DeviceType Methods
         /// <summary>
         /// Gets a device type from the "deviceTypes" collection, given an objectID.
         /// </summary>
@@ -317,6 +324,6 @@ namespace BEIMA.Backend.MongoService
                 return null;
             }
         }
-
+        #endregion
     }
 }

--- a/BEIMA.DB.Schemas/building-schema.txt
+++ b/BEIMA.DB.Schemas/building-schema.txt
@@ -1,5 +1,5 @@
 {
-    "buildingId": String,
+    "_id": String,
     "name": String,
     "number": String,
     "notes": String,

--- a/BEIMA.DB.Schemas/device-schema.txt
+++ b/BEIMA.DB.Schemas/device-schema.txt
@@ -1,4 +1,5 @@
 {
+    "_id": ObjectId,
     "deviceTypeId": String,
     "deviceTag": String,
     "manufacturer": String,

--- a/BEIMA.DB.Schemas/device-type-schema.txt
+++ b/BEIMA.DB.Schemas/device-type-schema.txt
@@ -1,5 +1,5 @@
 {
-    "deviceTypeId": String,
+    "_id": ObjectId,
     "name": String,
     "description": String,
     "notes": String,


### PR DESCRIPTION
<!--
These comments inside these brackets will not appear in the pull request.

The pull request should be linked to either:
 - a task (i.e., use 'Closes #TaskID' or 'Resolves #TaskID')
 - a bug (i.e., use 'Closes #BugID' or 'Fixes #BugID')

For more details, see: https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes #81 - story
Closes #128 
Closes #129 
Closes #130 
Closes #131 
Closes #132 
Closes #132 
Closes #133

This PR implements DeviceType functionality in MongoConnector. It also implements the related unit tests, as well as the new environment variables in beima.yml. The code was mostly the same as the existing code for Device functionality, so it should look pretty similar.

There was also a change to the DB schemas. I removed the "deviceTypeId" and "buildingId" fields from the DeviceType and Building schemas respectively, since that would actually just be the "_id" field that is automatically generated when inserted into the database. I added the "_id" field to all of the schemas since that is what we will expect to see stored in the DB.
