### PR TITLE
Force user to enter numeric value for year manufactured 

### DIFF
--- a/BEIMA.Client/cypress/integration/AddDevicePage.spec.js
+++ b/BEIMA.Client/cypress/integration/AddDevicePage.spec.js
@@ -24,6 +24,8 @@ describe("Verify Data can be entered into fields", () => {
 describe("Verify Data in fields is cleared when Add Device is selected", () => {
   it('Enter data, click Add Device, verify fields are empty', () => {
     cy.visit('http://localhost:3000/addDevice')
+    cy.get("#typeDropDown").scrollIntoView().click()
+    cy.get("#typeDropDown").children().last().scrollIntoView().click()
     cy.get('#inputBuilding').scrollIntoView().type("Student Union Building")
     cy.get('#inputLatitude').scrollIntoView().type("10.34452345")
     cy.get("[id='inputSerial Number']").scrollIntoView().type("12345")
@@ -37,6 +39,8 @@ describe("Verify Data in fields is cleared when Add Device is selected", () => {
 describe("Verify Data in fields is still present when invalid coords exist and Add Device is selected", () => {
   it('Enter data, click Add Device, verify fields are empty', () => {
     cy.visit('http://localhost:3000/addDevice')
+    cy.get("#typeDropDown").scrollIntoView().click()
+    cy.get("#typeDropDown").children().last().scrollIntoView().click()
     cy.get('#inputBuilding').scrollIntoView().type("Student Union Building")
     cy.get('#inputLatitude').scrollIntoView().type("200")
     cy.get('#inputLongitude').scrollIntoView().type("200")
@@ -46,6 +50,23 @@ describe("Verify Data in fields is still present when invalid coords exist and A
     cy.get('#inputLatitude').should('have.value', '200')
     cy.get('#inputLongitude').should('have.value', '200')
     cy.get("[id='inputSerial Number']").should('have.value', '12345')
+  })
+})
+
+describe("Verify Data in fields is still present when invalid year manufactured exist and Add Device is selected", () => {
+  it('Enter data, click Add Device, verify fields are empty', () => {
+    cy.visit('http://localhost:3000/addDevice')
+    cy.get("#typeDropDown").scrollIntoView().click()
+    cy.get("#typeDropDown").children().last().scrollIntoView().click()
+    cy.get('#inputBuilding').scrollIntoView().type("Student Union Building")
+    cy.get('#inputLatitude').scrollIntoView().type("34")
+    cy.get('#inputLongitude').scrollIntoView().type("56")
+    cy.get("[id='inputYear Manufactured']").scrollIntoView().type("Not valid")
+    cy.get("#addDevice").scrollIntoView().click()
+    cy.get('#inputBuilding').should('have.value', 'Student Union Building')
+    cy.get('#inputLatitude').should('have.value', '34')
+    cy.get('#inputLongitude').should('have.value', '56')
+    cy.get("[id='inputYear Manufactured']").should('have.value', 'Not valid')
   })
 })
 

--- a/BEIMA.Client/src/Constants.js
+++ b/BEIMA.Client/src/Constants.js
@@ -1,4 +1,5 @@
 export const MAX_INPUT_CHARACTER_LENGTH = "1024"
+export const MAX_YEAR_LENGTH = "4"
 export const MAX_LONGITUDE = 180
 export const MAX_LATITUDE = 90
 export const HTTP_SUCCESS = 200

--- a/BEIMA.Client/src/pages/Devices/AddDevicePage.js
+++ b/BEIMA.Client/src/pages/Devices/AddDevicePage.js
@@ -97,6 +97,13 @@ const AddDevicePage = () => {
             newErrors[formName] = `${formName} value is invalid. Must be a decimal between -${coordMax} and ${coordMax}.`;
           }
         }
+
+        //year manufactured validation
+        if (formName === 'Year Manufactured') {
+          if(formFields[i].value.match(/[^\d]/)) {
+            newErrors[formName] = `${formName} value is invalid. Must be a valid year.`;
+          }
+        }
         
         Object.assign(fieldValues, formJSON);
       } else if (formName === "Device Image"){

--- a/BEIMA.Client/src/pages/Devices/AddDevicePage.js
+++ b/BEIMA.Client/src/pages/Devices/AddDevicePage.js
@@ -158,7 +158,7 @@ const AddDevicePage = () => {
       //year manufactured validation
       if (formName === 'Year Manufactured') {
         if(formFields[i].value.match(/[^\d]/)) {
-          newErrors[formName] = `${formName} value is invalid. Must be a valid year.`;
+          newErrors[formName] = `${formName} value is invalid. Must be a numeric value.`;
         }
       }
       

--- a/BEIMA.Client/src/pages/Devices/AddDevicePage.js
+++ b/BEIMA.Client/src/pages/Devices/AddDevicePage.js
@@ -135,21 +135,23 @@ const AddDevicePage = () => {
   function saveDeviceToDb(addButtonEvent) {
     const formFields = addButtonEvent.target.form.elements;
     const dbJson = createJSON(formFields);
-    AddDevice(dbJson).then(response => {
-      //reset the form or show a message regarding insertion failure
-      if(response.status === HTTP_SUCCESS){
-        setErrors({});
-        setSelectedDeviceType(noDeviceTypeObj);
-        setDropDownStyle(styles.button);
-        for(let i = 0; i < formFields.length; i++){
-          formFields[i].value = "";
+    if(dbJson){
+      AddDevice(dbJson).then(response => {
+        //reset the form or show a message regarding insertion failure
+        if(response.status === HTTP_SUCCESS){
+          setErrors({});
+          setSelectedDeviceType(noDeviceTypeObj);
+          setDropDownStyle(styles.button);
+          for(let i = 0; i < formFields.length; i++){
+            formFields[i].value = "";
+          }
+          /* TODO add success messaging*/
+        } else {
+          /*TODO push error to display*/
+          alert('API responded with: ' + response.status + ' ' + response.response);
         }
-        /* TODO add success messaging*/
-      } else {
-        /*TODO push error to display*/
-        alert('API responded with: ' + response.status + ' ' + response.response);
-      }
-    })
+      })
+    }
   }
   
   /*
@@ -185,6 +187,8 @@ const AddDevicePage = () => {
       if (formName === 'Year Manufactured') {
         if(formFields[i].value.match(/[^\d]/)) {
           newErrors[formName] = `${formName} value is invalid. Must be a numeric value.`;
+        } else if (formFields[i].value.length < 4 && formFields[i].value.length > 0){
+          newErrors[formName] = `${formName} value is invalid. Year must be 4 characters long.`;
         }
       }
       
@@ -217,6 +221,7 @@ const AddDevicePage = () => {
     //display errors when present or attempt insert when valid data is present
     if ( Object.keys(newErrors).length > 0 ) {
       setErrors(newErrors);
+      return false;
     } else {
       /*TODO Need ability to get a building ID, probably a DD on the page*/
 

--- a/BEIMA.Client/src/pages/Devices/DevicePage.js
+++ b/BEIMA.Client/src/pages/Devices/DevicePage.js
@@ -255,6 +255,10 @@ const DevicePage = () => {
       } else if (target === 'deviceSerialNumber'){
         setSerialNum(value)
       } else if (target === 'deviceYearManufactured'){
+        //year manufactured validation
+        if(value.match(/[^\d]/)) {
+          return;
+        }
         setYearManufactured(value)
       } else if (target === 'locationNotes'){
         setLocNotes(value)

--- a/BEIMA.Client/src/shared/FormList/FormListWithErrorFeedback.js
+++ b/BEIMA.Client/src/shared/FormList/FormListWithErrorFeedback.js
@@ -7,7 +7,9 @@ const FormList = ({fields, errors, changeHandler}) => {
         {fields.map(element =>
           <Form.Group key={element} id={element}>
             <Form.Label>{element}</Form.Label>
-            <Form.Control id={"input" + element} type="text" name={element} placeholder={"Enter " + element} isInvalid={errors[element]} maxLength={Constants.MAX_INPUT_CHARACTER_LENGTH} onChange={changeHandler} />
+            {element.toString().toLowerCase().includes("year") ?
+              <Form.Control id={"input" + element} type="text" name={element} placeholder={"Enter " + element} isInvalid={errors[element]} maxLength={Constants.MAX_YEAR_LENGTH} onChange={changeHandler}/>
+            : <Form.Control id={"input" + element} type="text" name={element} placeholder={"Enter " + element} isInvalid={errors[element]} maxLength={Constants.MAX_INPUT_CHARACTER_LENGTH} onChange={changeHandler}/>}
               <Form.Control.Feedback type='invalid'> { errors[element]}</Form.Control.Feedback>
           </Form.Group>
         )} 


### PR DESCRIPTION
<!--
These comments inside these brackets will not appear in the pull request.

The pull request should be linked to either:
 - a task (i.e., use 'Closes #TaskID' or 'Resolves #TaskID')
 - a bug (i.e., use 'Closes #BugID' or 'Fixes #BugID')

For more details, see: https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes #297

In the add device page, if the year manufactured value contains any non-numeric chars, it will show an error message to the user and won't let the user add the device. When editing a device, the user will not be able to input any non-numeric values. 
![image](https://user-images.githubusercontent.com/58532471/158851307-b7b9ea37-aed2-4c0e-bb13-60c072874724.png)

The destination branch is Tom's PR, and there are many diffs because his branch isn't up to date with master. That's okay, we can wait for his PR to merge before we merge this one. 
