### PR TITLE
Refactor MongoConnector to abstract out basic CRUD calls

### DIFF
--- a/BEIMA.Backend/MongoService/MongoConnector.cs
+++ b/BEIMA.Backend/MongoService/MongoConnector.cs
@@ -286,21 +286,7 @@ namespace BEIMA.Backend.MongoService
         /// <returns>BsonDocument that was requested</returns>
         public BsonDocument GetBuilding(ObjectId objectId)
         {
-            CheckIsConnected();
-
-            var filter = Builders<BsonDocument>.Filter.Eq("_id", objectId);
-
-            try
-            {
-                var db = client.GetDatabase(dbName);
-                var buildings = db.GetCollection<BsonDocument>(buildingCollection);
-                return buildings.Find(filter).FirstOrDefault();
-            }
-            catch (Exception ex)
-            {
-                Console.Error.WriteLine(ex.Message);
-                return null;
-            }
+            return Get(objectId, beimaDb, buildingCollection);
         }
 
         /// <summary>
@@ -309,22 +295,7 @@ namespace BEIMA.Backend.MongoService
         /// <returns>List of all building BsonDocuments</returns>
         public List<BsonDocument> GetAllBuildings()
         {
-            CheckIsConnected();
-
-            var filter = Builders<BsonDocument>.Filter.Empty;
-
-            try
-            {
-                var db = client.GetDatabase(dbName);
-                var buildings = db.GetCollection<BsonDocument>(buildingCollection);
-                var docs = buildings.Find(filter).ToList();
-                return docs;
-            }
-            catch (Exception ex)
-            {
-                Console.Error.WriteLine(ex.Message);
-                return null;
-            }
+            return GetAll(beimaDb, buildingCollection);
         }
 
         /// <summary>
@@ -334,20 +305,7 @@ namespace BEIMA.Backend.MongoService
         /// <returns>ObjectId of the newly inserted object if successful, null if failed</returns>
         public ObjectId? InsertBuilding(BsonDocument doc)
         {
-            CheckIsConnected();
-
-            try
-            {
-                var db = client.GetDatabase(dbName);
-                var buildings = db.GetCollection<BsonDocument>(buildingCollection);
-                buildings.InsertOne(doc);
-                return (ObjectId)doc["_id"];
-            }
-            catch (Exception ex)
-            {
-                Console.Error.WriteLine(ex.Message);
-                return null;
-            }
+            return Insert(doc, beimaDb, buildingCollection);
         }
 
         /// <summary>
@@ -357,22 +315,7 @@ namespace BEIMA.Backend.MongoService
         /// <returns>true if successful, false if not successful</returns>
         public bool DeleteBuilding(ObjectId objectId)
         {
-            CheckIsConnected();
-
-            var filter = Builders<BsonDocument>.Filter.Eq("_id", objectId);
-
-            try
-            {
-                var db = client.GetDatabase(dbName);
-                var buildings = db.GetCollection<BsonDocument>(buildingCollection);
-                var result = buildings.DeleteOne(filter);
-                return result.DeletedCount > 0;
-            }
-            catch (Exception ex)
-            {
-                Console.Error.WriteLine(ex.Message);
-                return false;
-            }
+            return Delete(objectId, beimaDb, buildingCollection);
         }
 
         /// <summary>
@@ -382,29 +325,7 @@ namespace BEIMA.Backend.MongoService
         /// <returns>true if successful, false if unsuccessful</returns>
         public BsonDocument UpdateBuilding(BsonDocument doc)
         {
-            CheckIsConnected();
-
-            try
-            {
-                ObjectId objectId = (ObjectId)doc["_id"];
-                var filter = Builders<BsonDocument>.Filter.Eq("_id", objectId);
-                var db = client.GetDatabase(dbName);
-                var buildings = db.GetCollection<BsonDocument>(buildingCollection);
-                var result = buildings.ReplaceOne(filter, doc);
-                if (result.ModifiedCount > 0)
-                {
-                    return doc;
-                }
-                else
-                {
-                    return null;
-                }
-            }
-            catch (Exception ex)
-            {
-                Console.Error.WriteLine(ex.Message);
-                return null;
-            }
+            return Update(doc, beimaDb, buildingCollection);
         }
 
         #endregion

--- a/BEIMA.Backend/MongoService/MongoConnector.cs
+++ b/BEIMA.Backend/MongoService/MongoConnector.cs
@@ -180,20 +180,7 @@ namespace BEIMA.Backend.MongoService
         /// <returns>ObjectId of the newly inserted object if successful, null if failed</returns>
         public ObjectId? InsertDevice(BsonDocument doc)
         {
-            CheckIsConnected();
-
-            try
-            {
-                var db = client.GetDatabase(dbName);
-                var devices = db.GetCollection<BsonDocument>(deviceCollection);
-                devices.InsertOne(doc);
-                return (ObjectId)doc["_id"];
-            }
-            catch (Exception ex)
-            {
-                Console.Error.WriteLine(ex.Message);
-                return null;
-            }
+            return Insert(doc, beimaDb, deviceCollection);
         }
 
         /// <summary>
@@ -203,21 +190,7 @@ namespace BEIMA.Backend.MongoService
         /// <returns>BsonDocument that was requested</returns>
         public BsonDocument GetDevice(ObjectId objectId)
         {
-            CheckIsConnected();
-
-            var filter = Builders<BsonDocument>.Filter.Eq("_id", objectId);
-
-            try
-            {
-                var db = client.GetDatabase(dbName);
-                var devices = db.GetCollection<BsonDocument>(deviceCollection);
-                return devices.Find(filter).FirstOrDefault();
-            }
-            catch (Exception ex)
-            {
-                Console.Error.WriteLine(ex.Message);
-                return null;
-            }
+            return Get(objectId, beimaDb, deviceCollection);
         }
 
         /// <summary>
@@ -226,22 +199,7 @@ namespace BEIMA.Backend.MongoService
         /// <returns>BsonDocument that was requested</returns>
         public List<BsonDocument> GetAllDevices()
         {
-            CheckIsConnected();
-
-            var filter = Builders<BsonDocument>.Filter.Empty;
-
-            try
-            {
-                var db = client.GetDatabase(dbName);
-                var devices = db.GetCollection<BsonDocument>(deviceCollection);
-                var docs = devices.Find(filter).ToList();
-                return docs;
-            }
-            catch (Exception ex)
-            {
-                Console.Error.WriteLine(ex.Message);
-                return null;
-            }
+            return GetAll(beimaDb, deviceCollection);
         }
 
         /// <summary>
@@ -251,22 +209,7 @@ namespace BEIMA.Backend.MongoService
         /// <returns>true if successful, false if not successful</returns>
         public bool DeleteDevice(ObjectId objectId)
         {
-            CheckIsConnected();
-
-            var filter = Builders<BsonDocument>.Filter.Eq("_id", objectId);
-
-            try
-            {
-                var db = client.GetDatabase(dbName);
-                var devices = db.GetCollection<BsonDocument>(deviceCollection);
-                var result = devices.DeleteOne(filter);
-                return result.DeletedCount > 0;
-            }
-            catch (Exception ex)
-            {
-                Console.Error.WriteLine(ex.Message);
-                return false;
-            }
+            return Delete(objectId, beimaDb, deviceCollection);
         }
 
         /// <summary>
@@ -276,29 +219,7 @@ namespace BEIMA.Backend.MongoService
         /// <returns>true if successful, false if unsuccessful</returns>
         public BsonDocument UpdateDevice(BsonDocument doc)
         {
-            CheckIsConnected();
-
-            try
-            {
-                ObjectId objectId = (ObjectId)doc["_id"];
-                var filter = Builders<BsonDocument>.Filter.Eq("_id", objectId);
-                var db = client.GetDatabase(dbName);
-                var devices = db.GetCollection<BsonDocument>(deviceCollection);
-                var result = devices.ReplaceOne(filter, doc);
-                if (result.ModifiedCount > 0)
-                {
-                    return doc;
-                }
-                else
-                {
-                    return null;
-                }
-            }
-            catch (Exception ex)
-            {
-                Console.Error.WriteLine(ex.Message);
-                return null;
-            }
+            return Update(doc, beimaDb, deviceCollection);
         }
         #endregion
 

--- a/BEIMA.Backend/MongoService/MongoConnector.cs
+++ b/BEIMA.Backend/MongoService/MongoConnector.cs
@@ -68,6 +68,63 @@ namespace BEIMA.Backend.MongoService
             }
         }
 
+        private ObjectId? Insert(BsonDocument doc, string collectionName)
+        {
+            CheckIsConnected();
+
+            try
+            {
+                var db = client.GetDatabase(dbName);
+                var collection = db.GetCollection<BsonDocument>(collectionName);
+                collection.InsertOne(doc);
+                return (ObjectId)doc["_id"];
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine(ex.Message);
+                return null;
+            }
+        }
+
+        private BsonDocument Get(ObjectId objectId, string collectionName)
+        {
+            CheckIsConnected();
+
+            var filter = Builders<BsonDocument>.Filter.Eq("_id", objectId);
+
+            try
+            {
+                var db = client.GetDatabase(dbName);
+                var collection = db.GetCollection<BsonDocument>(collectionName);
+                return collection.Find(filter).FirstOrDefault();
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine(ex.Message);
+                return null;
+            }
+        }
+
+        private List<BsonDocument> GetAll()
+        {
+            CheckIsConnected();
+
+            var filter = Builders<BsonDocument>.Filter.Empty;
+
+            try
+            {
+                var db = client.GetDatabase(dbName);
+                var devices = db.GetCollection<BsonDocument>(deviceCollection);
+                var docs = devices.Find(filter).ToList();
+                return docs;
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine(ex.Message);
+                return null;
+            }
+        }
+
         #region Device Methods
         /// <summary>
         /// Inserts a device into the "devices" collection

--- a/BEIMA.Backend/MongoService/MongoConnector.cs
+++ b/BEIMA.Backend/MongoService/MongoConnector.cs
@@ -339,21 +339,7 @@ namespace BEIMA.Backend.MongoService
         /// <returns>BsonDocument that was requested</returns>
         public BsonDocument GetUser(ObjectId objectId)
         {
-            CheckIsConnected();
-
-            var filter = Builders<BsonDocument>.Filter.Eq("_id", objectId);
-
-            try
-            {
-                var db = client.GetDatabase(dbName);
-                var users = db.GetCollection<BsonDocument>(userCollection);
-                return users.Find(filter).FirstOrDefault();
-            }
-            catch (Exception ex)
-            {
-                Console.Error.WriteLine(ex.Message);
-                return null;
-            }
+            return Get(objectId, beimaDb, userCollection);
         }
 
         /// <summary>
@@ -362,22 +348,7 @@ namespace BEIMA.Backend.MongoService
         /// <returns>List of all user BsonDocuments</returns>
         public List<BsonDocument> GetAllUsers()
         {
-            CheckIsConnected();
-
-            var filter = Builders<BsonDocument>.Filter.Empty;
-
-            try
-            {
-                var db = client.GetDatabase(dbName);
-                var users = db.GetCollection<BsonDocument>(userCollection);
-                var docs = users.Find(filter).ToList();
-                return docs;
-            }
-            catch (Exception ex)
-            {
-                Console.Error.WriteLine(ex.Message);
-                return null;
-            }
+            return GetAll(beimaDb, userCollection);
         }
 
         /// <summary>
@@ -387,20 +358,7 @@ namespace BEIMA.Backend.MongoService
         /// <returns>ObjectId of the newly inserted object if successful, null if failed</returns>
         public ObjectId? InsertUser(BsonDocument doc)
         {
-            CheckIsConnected();
-
-            try
-            {
-                var db = client.GetDatabase(dbName);
-                var users = db.GetCollection<BsonDocument>(userCollection);
-                users.InsertOne(doc);
-                return (ObjectId)doc["_id"];
-            }
-            catch (Exception ex)
-            {
-                Console.Error.WriteLine(ex.Message);
-                return null;
-            }
+            return Insert(doc, beimaDb, userCollection);
         }
 
         /// <summary>
@@ -410,22 +368,7 @@ namespace BEIMA.Backend.MongoService
         /// <returns>true if successful, false if not successful</returns>
         public bool DeleteUser(ObjectId objectId)
         {
-            CheckIsConnected();
-
-            var filter = Builders<BsonDocument>.Filter.Eq("_id", objectId);
-
-            try
-            {
-                var db = client.GetDatabase(dbName);
-                var users = db.GetCollection<BsonDocument>(userCollection);
-                var result = users.DeleteOne(filter);
-                return result.DeletedCount > 0;
-            }
-            catch (Exception ex)
-            {
-                Console.Error.WriteLine(ex.Message);
-                return false;
-            }
+            return Delete(objectId, beimaDb, userCollection);
         }
 
         /// <summary>
@@ -435,29 +378,7 @@ namespace BEIMA.Backend.MongoService
         /// <returns>true if successful, false if unsuccessful</returns>
         public BsonDocument UpdateUser(BsonDocument doc)
         {
-            CheckIsConnected();
-
-            try
-            {
-                ObjectId objectId = (ObjectId)doc["_id"];
-                var filter = Builders<BsonDocument>.Filter.Eq("_id", objectId);
-                var db = client.GetDatabase(dbName);
-                var users = db.GetCollection<BsonDocument>(userCollection);
-                var result = users.ReplaceOne(filter, doc);
-                if (result.ModifiedCount > 0)
-                {
-                    return doc;
-                }
-                else
-                {
-                    return null;
-                }
-            }
-            catch (Exception ex)
-            {
-                Console.Error.WriteLine(ex.Message);
-                return null;
-            }
+            return Update(doc, beimaDb, userCollection);
         }
 
         #endregion

--- a/BEIMA.Backend/MongoService/MongoConnector.cs
+++ b/BEIMA.Backend/MongoService/MongoConnector.cs
@@ -81,7 +81,7 @@ namespace BEIMA.Backend.MongoService
             }
             catch (Exception ex)
             {
-                Console.Error.WriteLine(ex.Message);
+                Console.Error.WriteLine($"{dbName} {collectionName}: {ex.Message}");
                 return null;
             }
         }
@@ -100,7 +100,7 @@ namespace BEIMA.Backend.MongoService
             }
             catch (Exception ex)
             {
-                Console.Error.WriteLine(ex.Message);
+                Console.Error.WriteLine($"{dbName} {collectionName}: {ex.Message}");
                 return null;
             }
         }
@@ -120,7 +120,7 @@ namespace BEIMA.Backend.MongoService
             }
             catch (Exception ex)
             {
-                Console.Error.WriteLine(ex.Message);
+                Console.Error.WriteLine($"{dbName} {collectionName}: {ex.Message}");
                 return null;
             }
         }
@@ -140,8 +140,35 @@ namespace BEIMA.Backend.MongoService
             }
             catch (Exception ex)
             {
-                Console.Error.WriteLine(ex.Message);
+                Console.Error.WriteLine($"{dbName} {collectionName}: {ex.Message}");
                 return false;
+            }
+        }
+
+        private BsonDocument Update(BsonDocument doc, string dbName, string collectionName)
+        {
+            CheckIsConnected();
+
+            try
+            {
+                ObjectId objectId = (ObjectId)doc["_id"];
+                var filter = Builders<BsonDocument>.Filter.Eq("_id", objectId);
+                var db = client.GetDatabase(dbName);
+                var collection = db.GetCollection<BsonDocument>(collectionName);
+                var result = collection.ReplaceOne(filter, doc);
+                if (result.ModifiedCount > 0)
+                {
+                    return doc;
+                }
+                else
+                {
+                    return null;
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine($"{dbName} {collectionName}: {ex.Message}");
+                return null;
             }
         }
 

--- a/BEIMA.Backend/MongoService/MongoConnector.cs
+++ b/BEIMA.Backend/MongoService/MongoConnector.cs
@@ -69,14 +69,14 @@ namespace BEIMA.Backend.MongoService
         }
 
         #region Base CRUD Methods
-        
+
         /// <summary>
         /// Inserts a BsonDocument into the given database/collection.
         /// </summary>
         /// <param name="doc">BsonDocument to insert.</param>
         /// <param name="dbName">Name of the database.</param>
         /// <param name="collectionName">Name of the collection.</param>
-        /// <returns></returns>
+        /// <returns>ObjectId of the newly inserted object if successful, null if failed</returns>
         private ObjectId? Insert(BsonDocument doc, string dbName, string collectionName)
         {
             CheckIsConnected();
@@ -101,7 +101,7 @@ namespace BEIMA.Backend.MongoService
         /// <param name="objectId">ObjectId of the object to be retrieved ("_id" field).</param>
         /// <param name="dbName">Name of the database.</param>
         /// <param name="collectionName">Name of the collection.</param>
-        /// <returns></returns>
+        /// <returns>BsonDocument that was requested</returns>
         private BsonDocument Get(ObjectId objectId, string dbName, string collectionName)
         {
             CheckIsConnected();
@@ -126,7 +126,7 @@ namespace BEIMA.Backend.MongoService
         /// </summary>
         /// <param name="dbName">Name of the database.</param>
         /// <param name="collectionName">Name of the collection.</param>
-        /// <returns></returns>
+        /// <returns>List of BsonDocuments that was requested</returns>
         private List<BsonDocument> GetAll(string dbName, string collectionName)
         {
             CheckIsConnected();
@@ -153,7 +153,7 @@ namespace BEIMA.Backend.MongoService
         /// <param name="objectId">The ObjectId of the object to delete. ("_id" field)</param>
         /// <param name="dbName">Name of the database.</param>
         /// <param name="collectionName">Name of the collection.</param>
-        /// <returns></returns>
+        /// <returns>true if successful, false if not successful</returns>
         private bool Delete(ObjectId objectId, string dbName, string collectionName)
         {
             CheckIsConnected();
@@ -180,7 +180,7 @@ namespace BEIMA.Backend.MongoService
         /// <param name="doc">The fully formed updated BsonDocument.</param>
         /// <param name="dbName">Name of the database.</param>
         /// <param name="collectionName">Name of the collection.</param>
-        /// <returns></returns>
+        /// <returns>true if successful, false if not successful</returns>
         private BsonDocument Update(BsonDocument doc, string dbName, string collectionName)
         {
             CheckIsConnected();
@@ -232,9 +232,9 @@ namespace BEIMA.Backend.MongoService
         }
 
         /// <summary>
-        /// Gets a device from the "devices" collection, given an objectID.
+        /// Gets all devices from the "devices" collection.
         /// </summary>
-        /// <returns>BsonDocument that was requested</returns>
+        /// <returns>List of BsonDocuments that was requested</returns>
         public List<BsonDocument> GetAllDevices()
         {
             return GetAll(beimaDb, deviceCollection);

--- a/BEIMA.Backend/MongoService/MongoConnector.cs
+++ b/BEIMA.Backend/MongoService/MongoConnector.cs
@@ -69,6 +69,14 @@ namespace BEIMA.Backend.MongoService
         }
 
         #region Base CRUD Methods
+        
+        /// <summary>
+        /// Inserts a BsonDocument into the given database/collection.
+        /// </summary>
+        /// <param name="doc">BsonDocument to insert.</param>
+        /// <param name="dbName">Name of the database.</param>
+        /// <param name="collectionName">Name of the collection.</param>
+        /// <returns></returns>
         private ObjectId? Insert(BsonDocument doc, string dbName, string collectionName)
         {
             CheckIsConnected();
@@ -87,6 +95,13 @@ namespace BEIMA.Backend.MongoService
             }
         }
 
+        /// <summary>
+        /// Gets a single BsonDocument from the given database/collection, given an ObjectId.
+        /// </summary>
+        /// <param name="objectId">ObjectId of the object to be retrieved ("_id" field).</param>
+        /// <param name="dbName">Name of the database.</param>
+        /// <param name="collectionName">Name of the collection.</param>
+        /// <returns></returns>
         private BsonDocument Get(ObjectId objectId, string dbName, string collectionName)
         {
             CheckIsConnected();
@@ -106,6 +121,12 @@ namespace BEIMA.Backend.MongoService
             }
         }
 
+        /// <summary>
+        /// Get all documents from the given database/collection.
+        /// </summary>
+        /// <param name="dbName">Name of the database.</param>
+        /// <param name="collectionName">Name of the collection.</param>
+        /// <returns></returns>
         private List<BsonDocument> GetAll(string dbName, string collectionName)
         {
             CheckIsConnected();
@@ -126,6 +147,13 @@ namespace BEIMA.Backend.MongoService
             }
         }
 
+        /// <summary>
+        /// Deletes one document given an ObjectId, from the given database/collection.
+        /// </summary>
+        /// <param name="objectId">The ObjectId of the object to delete. ("_id" field)</param>
+        /// <param name="dbName">Name of the database.</param>
+        /// <param name="collectionName">Name of the collection.</param>
+        /// <returns></returns>
         private bool Delete(ObjectId objectId, string dbName, string collectionName)
         {
             CheckIsConnected();
@@ -146,6 +174,13 @@ namespace BEIMA.Backend.MongoService
             }
         }
 
+        /// <summary>
+        /// Replaces a single document given the updated BsonDocument, inside the given database/collection.
+        /// </summary>
+        /// <param name="doc">The fully formed updated BsonDocument.</param>
+        /// <param name="dbName">Name of the database.</param>
+        /// <param name="collectionName">Name of the collection.</param>
+        /// <returns></returns>
         private BsonDocument Update(BsonDocument doc, string dbName, string collectionName)
         {
             CheckIsConnected();

--- a/BEIMA.Backend/MongoService/MongoConnector.cs
+++ b/BEIMA.Backend/MongoService/MongoConnector.cs
@@ -105,7 +105,7 @@ namespace BEIMA.Backend.MongoService
             }
         }
 
-        private List<BsonDocument> GetAll()
+        private List<BsonDocument> GetAll(string collectionName)
         {
             CheckIsConnected();
 
@@ -114,8 +114,8 @@ namespace BEIMA.Backend.MongoService
             try
             {
                 var db = client.GetDatabase(dbName);
-                var devices = db.GetCollection<BsonDocument>(deviceCollection);
-                var docs = devices.Find(filter).ToList();
+                var collection = db.GetCollection<BsonDocument>(collectionName);
+                var docs = collection.Find(filter).ToList();
                 return docs;
             }
             catch (Exception ex)

--- a/BEIMA.Backend/MongoService/MongoConnector.cs
+++ b/BEIMA.Backend/MongoService/MongoConnector.cs
@@ -68,6 +68,7 @@ namespace BEIMA.Backend.MongoService
             }
         }
 
+        #region Base CRUD Methods
         private ObjectId? Insert(BsonDocument doc, string dbName, string collectionName)
         {
             CheckIsConnected();
@@ -172,6 +173,8 @@ namespace BEIMA.Backend.MongoService
             }
         }
 
+        #endregion
+
         #region Device Methods
         /// <summary>
         /// Inserts a device into the "devices" collection
@@ -231,21 +234,7 @@ namespace BEIMA.Backend.MongoService
         /// <returns>BsonDocument that was requested</returns>
         public BsonDocument GetDeviceType(ObjectId objectId)
         {
-            CheckIsConnected();
-
-            var filter = Builders<BsonDocument>.Filter.Eq("_id", objectId);
-
-            try
-            {
-                var db = client.GetDatabase(dbName);
-                var deviceTypes = db.GetCollection<BsonDocument>(deviceTypeCollection);
-                return deviceTypes.Find(filter).FirstOrDefault();
-            }
-            catch (Exception ex)
-            {
-                Console.Error.WriteLine(ex.Message);
-                return null;
-            }
+            return Get(objectId, beimaDb, deviceTypeCollection);
         }
 
         /// <summary>
@@ -254,22 +243,7 @@ namespace BEIMA.Backend.MongoService
         /// <returns>BsonDocument that was requested</returns>
         public List<BsonDocument> GetAllDeviceTypes()
         {
-            CheckIsConnected();
-
-            var filter = Builders<BsonDocument>.Filter.Empty;
-
-            try
-            {
-                var db = client.GetDatabase(dbName);
-                var deviceTypes = db.GetCollection<BsonDocument>(deviceTypeCollection);
-                var docs = deviceTypes.Find(filter).ToList();
-                return docs;
-            }
-            catch (Exception ex)
-            {
-                Console.Error.WriteLine(ex.Message);
-                return null;
-            }
+            return GetAll(beimaDb, deviceTypeCollection);
         }
 
         /// <summary>
@@ -279,20 +253,7 @@ namespace BEIMA.Backend.MongoService
         /// <returns>ObjectId of the newly inserted object if successful, null if failed</returns>
         public ObjectId? InsertDeviceType(BsonDocument doc)
         {
-            CheckIsConnected();
-
-            try
-            {
-                var db = client.GetDatabase(dbName);
-                var deviceTypes = db.GetCollection<BsonDocument>(deviceTypeCollection);
-                deviceTypes.InsertOne(doc);
-                return (ObjectId)doc["_id"];
-            }
-            catch (Exception ex)
-            {
-                Console.Error.WriteLine(ex.Message);
-                return null;
-            }
+            return Insert(doc, beimaDb, deviceTypeCollection);
         }
 
         /// <summary>
@@ -302,22 +263,7 @@ namespace BEIMA.Backend.MongoService
         /// <returns>true if successful, false if not successful</returns>
         public bool DeleteDeviceType(ObjectId objectId)
         {
-            CheckIsConnected();
-
-            var filter = Builders<BsonDocument>.Filter.Eq("_id", objectId);
-
-            try
-            {
-                var db = client.GetDatabase(dbName);
-                var deviceTypes = db.GetCollection<BsonDocument>(deviceTypeCollection);
-                var result = deviceTypes.DeleteOne(filter);
-                return result.DeletedCount > 0;
-            }
-            catch (Exception ex)
-            {
-                Console.Error.WriteLine(ex.Message);
-                return false;
-            }
+            return Delete(objectId, beimaDb, deviceTypeCollection);
         }
 
         /// <summary>
@@ -327,29 +273,7 @@ namespace BEIMA.Backend.MongoService
         /// <returns>true if successful, false if unsuccessful</returns>
         public BsonDocument UpdateDeviceType(BsonDocument doc)
         {
-            CheckIsConnected();
-
-            try
-            {
-                ObjectId objectId = (ObjectId)doc["_id"];
-                var filter = Builders<BsonDocument>.Filter.Eq("_id", objectId);
-                var db = client.GetDatabase(dbName);
-                var deviceTypes = db.GetCollection<BsonDocument>(deviceTypeCollection);
-                var result = deviceTypes.ReplaceOne(filter, doc);
-                if (result.ModifiedCount > 0)
-                {
-                    return doc;
-                }
-                else
-                {
-                    return null;
-                }
-            }
-            catch (Exception ex)
-            {
-                Console.Error.WriteLine(ex.Message);
-                return null;
-            }
+            return Update(doc, beimaDb, deviceTypeCollection);
         }
         #endregion
 

--- a/BEIMA.Backend/MongoService/MongoConnector.cs
+++ b/BEIMA.Backend/MongoService/MongoConnector.cs
@@ -20,7 +20,7 @@ namespace BEIMA.Backend.MongoService
         private static readonly Lazy<MongoConnector> instance = new(() => new MongoConnector());
 
         //Environment variables
-        private readonly string dbName = Environment.GetEnvironmentVariable("DatabaseName");
+        private readonly string beimaDb = Environment.GetEnvironmentVariable("DatabaseName");
         private readonly string deviceCollection = Environment.GetEnvironmentVariable("DeviceCollectionName");
         private readonly string deviceTypeCollection = Environment.GetEnvironmentVariable("DeviceTypeCollectionName");
         private readonly string buildingCollection = Environment.GetEnvironmentVariable("BuildingCollectionName");
@@ -68,7 +68,7 @@ namespace BEIMA.Backend.MongoService
             }
         }
 
-        private ObjectId? Insert(BsonDocument doc, string collectionName)
+        private ObjectId? Insert(BsonDocument doc, string dbName, string collectionName)
         {
             CheckIsConnected();
 
@@ -86,7 +86,7 @@ namespace BEIMA.Backend.MongoService
             }
         }
 
-        private BsonDocument Get(ObjectId objectId, string collectionName)
+        private BsonDocument Get(ObjectId objectId, string dbName, string collectionName)
         {
             CheckIsConnected();
 
@@ -105,7 +105,7 @@ namespace BEIMA.Backend.MongoService
             }
         }
 
-        private List<BsonDocument> GetAll(string collectionName)
+        private List<BsonDocument> GetAll(string dbName, string collectionName)
         {
             CheckIsConnected();
 
@@ -122,6 +122,26 @@ namespace BEIMA.Backend.MongoService
             {
                 Console.Error.WriteLine(ex.Message);
                 return null;
+            }
+        }
+
+        private bool Delete(ObjectId objectId, string dbName, string collectionName)
+        {
+            CheckIsConnected();
+
+            var filter = Builders<BsonDocument>.Filter.Eq("_id", objectId);
+
+            try
+            {
+                var db = client.GetDatabase(dbName);
+                var collection = db.GetCollection<BsonDocument>(collectionName);
+                var result = collection.DeleteOne(filter);
+                return result.DeletedCount > 0;
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine(ex.Message);
+                return false;
             }
         }
 


### PR DESCRIPTION
<!--
These comments inside these brackets will not appear in the pull request.

The pull request should be linked to either:
 - a task (i.e., use 'Closes #TaskID' or 'Resolves #TaskID')
 - a bug (i.e., use 'Closes #BugID' or 'Fixes #BugID')

For more details, see: https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes #327 

This PR abstracts out a lot of the basic CRUD calls in the MongoConnector. I realized that there does not need to be a separate implementation for each POCO, and it can all be abstracted. This will make adding on new MongoConnector functionality much easier in the future.