### PR TITLE
329 add storage to get/delete device endpoints

### DIFF
--- a/BEIMA.Backend.FT/BEIMA.Backend.FT.csproj
+++ b/BEIMA.Backend.FT/BEIMA.Backend.FT.csproj
@@ -17,4 +17,8 @@
     <PackageReference Include="coverlet.collector" Version="3.1.0" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\BEIMA.Backend\BEIMA.Backend.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/BEIMA.Backend.FT/BEIMA.Backend.FT.csproj
+++ b/BEIMA.Backend.FT/BEIMA.Backend.FT.csproj
@@ -17,8 +17,4 @@
     <PackageReference Include="coverlet.collector" Version="3.1.0" />
   </ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\BEIMA.Backend\BEIMA.Backend.csproj" />
-  </ItemGroup>
-
 </Project>

--- a/BEIMA.Backend.FT/DeviceFT.cs
+++ b/BEIMA.Backend.FT/DeviceFT.cs
@@ -1,5 +1,4 @@
-﻿using BEIMA.Backend.StorageService;
-using Microsoft.AspNetCore.Http.Internal;
+﻿using Microsoft.AspNetCore.Http.Internal;
 using MongoDB.Driver;
 using NUnit.Framework;
 using System.Collections.Generic;

--- a/BEIMA.Backend.FT/DeviceFT.cs
+++ b/BEIMA.Backend.FT/DeviceFT.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http.Internal;
+﻿using BEIMA.Backend.StorageService;
+using Microsoft.AspNetCore.Http.Internal;
 using MongoDB.Driver;
 using NUnit.Framework;
 using System.Collections.Generic;
@@ -278,13 +279,41 @@ namespace BEIMA.Backend.FT
                 YearManufactured = 2000,
             };
 
-            var deviceId = await TestClient.AddDevice(device);
-            Assume.That(await TestClient.GetDevice(deviceId), Is.Not.Null);
+            FormFileCollection files = new FormFileCollection();
+            var fileName = "file.txt";
+            var photoName = "photo.txt";
+
+            string deviceId;
+            using (var fileStream = new MemoryStream(TestObjects._fileBytes))
+            using (var photoStream = new MemoryStream(TestObjects._fileBytes))
+            {
+                files.Add(new FormFile(fileStream, 0, fileStream.Length, "files", fileName));
+                files.Add(new FormFile(photoStream, 0, photoStream.Length, "photo", photoName));
+
+                // ACT
+                deviceId = await TestClient.AddDevice(device, files);
+            }
+
+            var response = await TestClient.GetDevice(deviceId);
+            Assert.That(response, Is.Not.Null);
+
+            var photoUid = response.Photo?.FileUid;
+            var fileUid = response.Files?[0].FileUid;
+
+            Assert.That(photoUid, Is.Not.Null);
+            Assert.That(fileUid, Is.Not.Null);
 
             // ACT
             Assert.DoesNotThrowAsync(async () => await TestClient.DeleteDevice(deviceId));
 
             // ASSERT
+            var _storage = StorageDefinition.StorageInstance;
+            var photoExists = _storage.GetFileExists(photoUid);
+            var fileExists = _storage.GetFileExists(fileUid);
+
+            Assert.That(photoExists, Is.False);
+            Assert.That(fileExists, Is.False);
+
             var ex = Assert.ThrowsAsync<BeimaException>(async () => await TestClient.GetDevice(deviceId));
             Assert.That(ex?.StatusCode, Is.EqualTo(HttpStatusCode.NotFound));
         }

--- a/BEIMA.Backend.FT/DeviceFT.cs
+++ b/BEIMA.Backend.FT/DeviceFT.cs
@@ -317,13 +317,6 @@ namespace BEIMA.Backend.FT
             Assert.DoesNotThrowAsync(async () => await TestClient.DeleteDevice(deviceId));
 
             // ASSERT
-            var _storage = StorageDefinition.StorageInstance;
-            var photoExists = _storage.GetFileExists(photoUid);
-            var fileExists = _storage.GetFileExists(fileUid);
-
-            Assert.That(photoExists, Is.False);
-            Assert.That(fileExists, Is.False);
-
             var ex = Assert.ThrowsAsync<BeimaException>(async () => await TestClient.GetDevice(deviceId));
             Assert.That(ex?.StatusCode, Is.EqualTo(HttpStatusCode.NotFound));
         }

--- a/BEIMA.Backend.Test/DeviceFunctions/DeleteDeviceTest.cs
+++ b/BEIMA.Backend.Test/DeviceFunctions/DeleteDeviceTest.cs
@@ -1,11 +1,14 @@
 ﻿using BEIMA.Backend.DeviceFunctions;
 using BEIMA.Backend.MongoService;
+using BEIMA.Backend.StorageService;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using MongoDB.Bson;
 using Moq;
 using NUnit.Framework;
+using System;
 using System.Net;
+using System.Threading.Tasks;
 using static BEIMA.Backend.Test.RequestFactory;
 
 namespace BEIMA.Backend.Test.DeviceFunctions
@@ -17,70 +20,92 @@ namespace BEIMA.Backend.Test.DeviceFunctions
         [TestCase("xxx")]
         [TestCase("123")]
         [TestCase("jddkkslo9402mdjgkflsnxjf")]
-        public void IdIsInvalid_DeleteDevice_ReturnsInvalidId(string id)
+        public async Task IdIsInvalid_DeleteDevice_ReturnsInvalidId(string id)
         {
             // ARRANGE
             Mock<IMongoConnector> mockDb = new Mock<IMongoConnector>();
             MongoDefinition.MongoInstance = mockDb.Object;
+            Mock<IStorageProvider> mockStorage = new Mock<IStorageProvider>();
+            StorageDefinition.StorageInstance = mockStorage.Object;
 
             var request = CreateHttpRequest(RequestMethod.POST);
             var logger = (new LoggerFactory()).CreateLogger("Testing");
 
             // ACT
-            var response = DeleteDevice.Run(request, id, logger);
+            var response = await DeleteDevice.Run(request, id, logger);
 
             // ASSERT
             Assert.DoesNotThrow(() => mockDb.Verify(mock => mock.DeleteDevice(It.IsAny<ObjectId>()), Times.Never));
+            Assert.DoesNotThrow(() => mockStorage.Verify(mock => mock.DeleteFile(It.IsAny<string>()), Times.Never));    
 
             Assert.That(response, Is.TypeOf(typeof(BadRequestObjectResult)));
             Assert.That(((BadRequestObjectResult)response).StatusCode, Is.EqualTo((int)HttpStatusCode.BadRequest));
         }
 
         [Test]
-        public void IdNotInDatabase_DeleteDevice_ReturnsNotFound()
+        public async Task IdNotInDatabase_DeleteDevice_ReturnsNotFound()
         {
             // ARRANGE
             var testId = ObjectId.GenerateNewId().ToString();
             Mock<IMongoConnector> mockDb = new Mock<IMongoConnector>();
-            mockDb.Setup(mock => mock.DeleteDevice(It.Is<ObjectId>(oid => oid == new ObjectId(testId))))
-                  .Returns(false)
+            mockDb.Setup(mock => mock.GetDevice(It.Is<ObjectId>(oid => oid == new ObjectId(testId))))
+                  .Returns<BsonDocument>(null)
                   .Verifiable();
             MongoDefinition.MongoInstance = mockDb.Object;
+            Mock<IStorageProvider> mockStorage = new Mock<IStorageProvider>();
+            StorageDefinition.StorageInstance = mockStorage.Object;
+
 
             var request = CreateHttpRequest(RequestMethod.POST);
             var logger = (new LoggerFactory()).CreateLogger("Testing");
 
             // ACT
-            var response = DeleteDevice.Run(request, testId, logger);
+            var response = await DeleteDevice.Run(request, testId, logger);
 
             // ASSERT
             Assert.DoesNotThrow(() => mockDb.Verify(mock => mock.DeleteDevice(It.IsAny<ObjectId>()), Times.Once));
+            Assert.DoesNotThrow(() => mockStorage.Verify(mock => mock.DeleteFile(It.IsAny<string>()), Times.Never));
 
             Assert.That(response, Is.TypeOf(typeof(NotFoundObjectResult)));
             Assert.That(((NotFoundObjectResult)response).StatusCode, Is.EqualTo((int)HttpStatusCode.NotFound));
         }
 
         [Test]
-        public void IdIsValid_DeleteDevice_DeletionSuccessful()
+        public async Task IdIsValid_DeleteDevice_DeletionSuccessful()
         {
             // ARRANGE
 
             var testId = "1234567890abcdef12345678";
+            var device = new Device(ObjectId.Parse(testId), ObjectId.GenerateNewId(), "A-1", "Generic Inc.", "43", "x46b", 2005, "Comment");
+            device.SetPhoto(Guid.NewGuid() + ".png", "photo");
+            device.AddFile(Guid.NewGuid() + ".txt", "file");
 
             Mock<IMongoConnector> mockDb = new Mock<IMongoConnector>();
+            mockDb.Setup(mock => mock.GetDevice(It.Is<ObjectId>(oid => oid == new ObjectId(testId))))
+                .Returns(device.GetBsonDocument())
+                .Verifiable();
             mockDb.Setup(mock => mock.DeleteDevice(It.Is<ObjectId>(oid => oid == new ObjectId(testId))))
-                  .Returns(true)
-                  .Verifiable();
+                .Returns(true)
+                .Verifiable();
             MongoDefinition.MongoInstance = mockDb.Object;
+            Mock<IStorageProvider> mockStorage = new Mock<IStorageProvider>();
+            mockStorage.Setup(mock => mock.DeleteFile(It.IsAny<string>()))
+                .Returns(Task.FromResult(true))
+                .Verifiable();
+
+            StorageDefinition.StorageInstance = mockStorage.Object;
 
             var request = CreateHttpRequest(RequestMethod.GET);
             var logger = (new LoggerFactory()).CreateLogger("Testing");
 
             // ACT
-            var response = DeleteDevice.Run(request, testId, logger);
+            var response = await DeleteDevice.Run(request, testId, logger);
 
             // ASSERT
+            Assert.DoesNotThrow(() => mockDb.Verify(mock => mock.GetDevice(It.IsAny<ObjectId>()), Times.Once));
             Assert.DoesNotThrow(() => mockDb.Verify(mock => mock.DeleteDevice(It.IsAny<ObjectId>()), Times.Once));
+
+            Assert.DoesNotThrow(() => mockStorage.Verify(mock => mock.DeleteFile(It.IsAny<string>()), Times.Exactly(2)));
 
             Assert.That(response, Is.TypeOf(typeof(OkResult)));
             Assert.That(((OkResult)response).StatusCode, Is.EqualTo((int)HttpStatusCode.OK));

--- a/BEIMA.Backend.Test/DeviceFunctions/DeleteDeviceTest.cs
+++ b/BEIMA.Backend.Test/DeviceFunctions/DeleteDeviceTest.cs
@@ -63,7 +63,8 @@ namespace BEIMA.Backend.Test.DeviceFunctions
             var response = await DeleteDevice.Run(request, testId, logger);
 
             // ASSERT
-            Assert.DoesNotThrow(() => mockDb.Verify(mock => mock.DeleteDevice(It.IsAny<ObjectId>()), Times.Once));
+            Assert.DoesNotThrow(() => mockDb.Verify(mock => mock.GetDevice(It.IsAny<ObjectId>()), Times.Once));
+            Assert.DoesNotThrow(() => mockDb.Verify(mock => mock.DeleteDevice(It.IsAny<ObjectId>()), Times.Never));
             Assert.DoesNotThrow(() => mockStorage.Verify(mock => mock.DeleteFile(It.IsAny<string>()), Times.Never));
 
             Assert.That(response, Is.TypeOf(typeof(NotFoundObjectResult)));
@@ -77,8 +78,10 @@ namespace BEIMA.Backend.Test.DeviceFunctions
 
             var testId = "1234567890abcdef12345678";
             var device = new Device(ObjectId.Parse(testId), ObjectId.GenerateNewId(), "A-1", "Generic Inc.", "43", "x46b", 2005, "Comment");
+            device.SetLastModified(DateTime.UtcNow, "Anonymous");
             device.SetPhoto(Guid.NewGuid() + ".png", "photo");
             device.AddFile(Guid.NewGuid() + ".txt", "file");
+            device.SetLocation(null,null,null,null); 
 
             Mock<IMongoConnector> mockDb = new Mock<IMongoConnector>();
             mockDb.Setup(mock => mock.GetDevice(It.Is<ObjectId>(oid => oid == new ObjectId(testId))))

--- a/BEIMA.Backend.Test/DeviceFunctions/GetDeviceTest.cs
+++ b/BEIMA.Backend.Test/DeviceFunctions/GetDeviceTest.cs
@@ -7,6 +7,7 @@ using NUnit.Framework;
 using System;
 using System.Collections.Generic;
 using System.Net;
+using System.Threading.Tasks;
 using static BEIMA.Backend.Test.RequestFactory;
 
 namespace BEIMA.Backend.Test
@@ -18,7 +19,7 @@ namespace BEIMA.Backend.Test
         #region FailureTests
 
         [Test]
-        public void IdNotInDatabase_GetDevice_ReturnsNotFound()
+        public async Task IdNotInDatabase_GetDevice_ReturnsNotFound()
         {
             // ARRANGE
 
@@ -35,7 +36,7 @@ namespace BEIMA.Backend.Test
             var logger = (new LoggerFactory()).CreateLogger("Testing");
 
             // ACT
-            var response = GetDevice.Run(request, testId, logger);
+            var response = await GetDevice.Run(request, testId, logger);
 
             // ASSERT
             Assert.DoesNotThrow(() => mockDb.Verify(mock => mock.GetDevice(It.IsAny<ObjectId>()), Times.Once));
@@ -49,7 +50,7 @@ namespace BEIMA.Backend.Test
         [TestCase("xxx")]
         [TestCase("123")]
         [TestCase("10alskdjfhgytur74839skcm")]
-        public void InvalidId_GetDevice_ReturnsInvalidId(string id)
+        public async Task InvalidId_GetDevice_ReturnsInvalidId(string id)
         {
             // ARRANGE
             Mock<IMongoConnector> mockDb = new Mock<IMongoConnector>();
@@ -62,7 +63,7 @@ namespace BEIMA.Backend.Test
             var logger = (new LoggerFactory()).CreateLogger("Testing");
 
             // ACT
-            var response = GetDevice.Run(request, id, logger);
+            var response = await GetDevice.Run(request, id, logger);
 
             // ASSERT
             Assert.DoesNotThrow(() => mockDb.Verify(mock => mock.GetDevice(It.IsAny<ObjectId>()), Times.Never));
@@ -77,7 +78,7 @@ namespace BEIMA.Backend.Test
         #region SuccessTests
 
         [Test]
-        public void IdIsValid_GetDevice_ReturnsDevice()
+        public async Task IdIsValid_GetDevice_ReturnsDevice()
         {
             // ARRANGE
 
@@ -97,7 +98,7 @@ namespace BEIMA.Backend.Test
             var logger = (new LoggerFactory()).CreateLogger("Testing");
 
             // ACT
-            var response = GetDevice.Run(request, testId, logger);
+            var response = await GetDevice.Run(request, testId, logger);
 
             // ASSERT
             Assert.DoesNotThrow(() => mockDb.Verify(mock => mock.GetDevice(It.IsAny<ObjectId>()), Times.Once));

--- a/BEIMA.Backend/DeviceFunctions/DeleteDevice.cs
+++ b/BEIMA.Backend/DeviceFunctions/DeleteDevice.cs
@@ -1,10 +1,15 @@
 using BEIMA.Backend.MongoService;
+using BEIMA.Backend.StorageService;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Azure.WebJobs;
 using Microsoft.Azure.WebJobs.Extensions.Http;
 using Microsoft.Extensions.Logging;
 using MongoDB.Bson;
+using MongoDB.Bson.Serialization;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
 
 namespace BEIMA.Backend.DeviceFunctions
 {
@@ -21,7 +26,7 @@ namespace BEIMA.Backend.DeviceFunctions
         /// <param name="log">The logger to log to.</param>
         /// <returns>An http response indicating whether or not the deletion was successful.</returns>
         [FunctionName("DeleteDevice")]
-        public static IActionResult Run(
+        public static async Task<IActionResult> Run(
             [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "device/{id}/delete")] HttpRequest req,
             string id,
             ILogger log)
@@ -36,9 +41,33 @@ namespace BEIMA.Backend.DeviceFunctions
             var mongo = MongoDefinition.MongoInstance;
             var deviceId = new ObjectId(id);
 
+            BsonDocument deviceDocument = mongo.GetDevice(deviceId);
+
+            // Check that the device returned is not null.
+            if (deviceDocument is null)
+            {
+                return new NotFoundObjectResult(Resources.DeviceNotFoundMessage);
+            }
+
+            // Return the device.
+            var device = BsonSerializer.Deserialize<Device>(deviceDocument);
             if (!mongo.DeleteDevice(deviceId))
             {
                 return new NotFoundObjectResult(Resources.DeviceNotFoundMessage);
+            }
+
+            // Create a list of file uids
+            List<string> filesToDelete = device.Files.Select(val => val.FileUid).ToList();
+            if(device.Photo.FileUid != null)
+            {
+                filesToDelete.Add(device.Photo.FileUid);
+            }
+
+            // Delete files from storage
+            var _storage = StorageDefinition.StorageInstance;
+            foreach (var fileUid in filesToDelete)
+            {
+                await _storage.DeleteFile(fileUid);
             }
 
             return new OkResult();


### PR DESCRIPTION
<!--
These comments inside these brackets will not appear in the pull request.

The pull request should be linked to either:
 - a task (i.e., use 'Closes #TaskID' or 'Resolves #TaskID')
 - a bug (i.e., use 'Closes #BugID' or 'Fixes #BugID')

For more details, see: https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes #329
Closes #15
References #228 

Added the storage provider to the get and delete endpoints.
