### PR TITLE
fixed no device type selected warning on add device page

### DIFF
--- a/BEIMA.Client/src/pages/Devices/AddDevicePage.js
+++ b/BEIMA.Client/src/pages/Devices/AddDevicePage.js
@@ -161,7 +161,7 @@ const AddDevicePage = () => {
   */
   function createJSON(formFields){
     //TODO temporary until we have error signaling figured out
-    if (selectedDeviceType === 'Select Device Type'){
+    if (selectedDeviceType.name === 'Select Device Type'){
       alert ('No device type selected');
       return;
     }


### PR DESCRIPTION
<!--
These comments inside these brackets will not appear in the pull request.

The pull request should be linked to either:
 - a task (i.e., use 'Closes #TaskID' or 'Resolves #TaskID')
 - a bug (i.e., use 'Closes #BugID' or 'Fixes #BugID')

For more details, see: https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes #168

when updating the text setter to a json object I neglected to update the check for no device type selected to match
