### PR TITLE
Implement filtering for Device in MongoConnector

### DIFF
--- a/BEIMA.Backend.Test/MongoService/MongoConnectorTest.cs
+++ b/BEIMA.Backend.Test/MongoService/MongoConnectorTest.cs
@@ -193,6 +193,14 @@ namespace BEIMA.Backend.Test.MongoService
         public void CreateFilterWithNoResults_GetFilteredDevices_NoResultsInList(string key, dynamic value)
         {
             var mongo = MongoConnector.Instance;
+            var doc = new BsonDocument
+            {
+                { "item", "isNotInDb" }
+            };
+            //Insert device
+            var insertResult = mongo.InsertDevice(doc);
+            Assume.That(insertResult, Is.Not.Null);
+            Assume.That(insertResult, Is.TypeOf(typeof(ObjectId)));
 
             //Create filter
             var filter = mongo.GetEqualsFilter(key, value);

--- a/BEIMA.Backend.Test/MongoService/MongoConnectorTest.cs
+++ b/BEIMA.Backend.Test/MongoService/MongoConnectorTest.cs
@@ -163,6 +163,47 @@ namespace BEIMA.Backend.Test.MongoService
             Assert.IsNull(result);
         }
 
+        [TestCase("serialNumber", "a12345")]
+        [TestCase("key1", 12345)]
+        [TestCase("key2", true)]
+        public void InsertDevice_GetFilteredDevices_DeviceInList(string key, dynamic value)
+        {
+            var mongo = MongoConnector.Instance;
+            var doc = new BsonDocument
+            {
+                { key, value }
+            };
+            //Insert device
+            var insertResult = mongo.InsertDevice(doc);
+            Assume.That(insertResult, Is.Not.Null);
+            Assume.That(insertResult, Is.TypeOf(typeof(ObjectId)));
+
+            //GetFiltered
+            var filter = mongo.GetEqualsFilter(key, value);
+            var list = mongo.GetFilteredDevices(filter);
+            foreach (var device in list)
+            {
+                Assert.That(device.GetElement(key).Value.ToString().ToLower(), Is.EqualTo(value.ToString().ToLower()));
+            }
+        }
+
+        [TestCase("InvalidKey1", "aaaaaaaaaaaa")]
+        [TestCase("aaaaaaaaaaaaaa", 12345)]
+        [TestCase("bbbbbbb", true)]
+        public void CreateFilterWithNoResults_GetFilteredDevices_NoResultsInList(string key, dynamic value)
+        {
+            var mongo = MongoConnector.Instance;
+
+            //Create filter
+            var filter = mongo.GetEqualsFilter(key, value);
+
+            //GetFilteredDevices
+            var list = mongo.GetFilteredDevices(filter);
+            
+            //NoResultsInList
+            Assert.That(list.Count, Is.EqualTo(0));
+        }
+
         #endregion
 
         #region DeviceType Tests

--- a/BEIMA.Backend.Test/MongoService/MongoConnectorTest.cs
+++ b/BEIMA.Backend.Test/MongoService/MongoConnectorTest.cs
@@ -179,7 +179,7 @@ namespace BEIMA.Backend.Test.MongoService
             Assume.That(insertResult, Is.TypeOf(typeof(ObjectId)));
 
             //GetFiltered
-            var filter = mongo.GetEqualsFilter(key, value);
+            var filter = MongoFilterGenerator.GetEqualsFilter(key, value);
             var list = mongo.GetFilteredDevices(filter);
             foreach (var device in list)
             {
@@ -203,7 +203,7 @@ namespace BEIMA.Backend.Test.MongoService
             Assume.That(insertResult, Is.TypeOf(typeof(ObjectId)));
 
             //Create filter
-            var filter = mongo.GetEqualsFilter(key, value);
+            var filter = MongoFilterGenerator.GetEqualsFilter(key, value);
 
             //GetFilteredDevices
             var list = mongo.GetFilteredDevices(filter);

--- a/BEIMA.Backend.Test/MongoService/MongoFilterGeneratorTest.cs
+++ b/BEIMA.Backend.Test/MongoService/MongoFilterGeneratorTest.cs
@@ -1,0 +1,51 @@
+﻿using BEIMA.Backend.MongoService;
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization;
+using MongoDB.Driver;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+
+namespace BEIMA.Backend.Test.MongoService
+{
+    [TestFixture]
+    public class MongoFilterGeneratorTest
+    {
+        [TestCase("abc", "ABCdef")]
+        [TestCase("def", 123)]
+        [TestCase("jjjjjjjjjjjjjjjj", true)]
+        public void FilterNotGenerated_GenerateEqualsFilter_FilterGenerated(string key, dynamic value)
+        {
+            //Create the filter
+            FilterDefinition<BsonDocument> filter = MongoFilterGenerator.GetEqualsFilter(key, value);
+
+            //Render the filter as a BsonDocument so we can run tests to make sure the filter is correct
+            var serializerRegistry = BsonSerializer.SerializerRegistry;
+            var documentSerializer = serializerRegistry.GetSerializer<BsonDocument>();
+            var doc = filter.Render(documentSerializer, serializerRegistry);
+
+            //Ensure filter is correct
+            Assert.That(filter, Is.Not.Null);
+            Assert.That(filter, Is.InstanceOf(typeof(FilterDefinition<BsonDocument>)));
+            Assert.That(doc.GetElement(key).Value?.ToString()?.ToLower(), Is.EqualTo(value.ToString().ToLower()));
+        }
+
+        [TestCase("nullValue", null)]
+        [TestCase("anotherNull12345", null)]
+        public void FilterNotGenerated_GenerateEqualsFilterUsingNullValue_FilterGenerated(string key, dynamic value)
+        {
+            //Create the filter
+            FilterDefinition<BsonDocument> filter = MongoFilterGenerator.GetEqualsFilter(key, value);
+
+            //Render the filter as a BsonDocument so we can run tests to make sure the filter is correct
+            var serializerRegistry = BsonSerializer.SerializerRegistry;
+            var documentSerializer = serializerRegistry.GetSerializer<BsonDocument>();
+            var doc = filter.Render(documentSerializer, serializerRegistry);
+
+            //Ensure filter is correct
+            Assert.That(filter, Is.Not.Null);
+            Assert.That(filter, Is.InstanceOf(typeof(FilterDefinition<BsonDocument>)));
+            Assert.That(doc.GetElement(key).Value, Is.EqualTo(BsonNull.Value));
+        }
+    }
+}

--- a/BEIMA.Backend/MongoService/MongoConnector.cs
+++ b/BEIMA.Backend/MongoService/MongoConnector.cs
@@ -104,15 +104,26 @@ namespace BEIMA.Backend.MongoService
         /// <returns>BsonDocument that was requested</returns>
         private BsonDocument Get(ObjectId objectId, string dbName, string collectionName)
         {
-            CheckIsConnected();
-
             var filter = Builders<BsonDocument>.Filter.Eq("_id", objectId);
+            return GetFiltered(filter, dbName, collectionName)?.FirstOrDefault();
+        }
+
+        /// <summary>
+        /// Gets a single BsonDocument from the given database/collection, given an ObjectId.
+        /// </summary>
+        /// <param name="filter">The filter that is being applied.</param>
+        /// <param name="dbName">Name of the database.</param>
+        /// <param name="collectionName">Name of the collection.</param>
+        /// <returns>BsonDocument that was requested</returns>
+        private List<BsonDocument> GetFiltered(FilterDefinition<BsonDocument> filter, string dbName, string collectionName)
+        {
+            CheckIsConnected();
 
             try
             {
                 var db = client.GetDatabase(dbName);
                 var collection = db.GetCollection<BsonDocument>(collectionName);
-                return collection.Find(filter).FirstOrDefault();
+                return collection.Find(filter).ToList();
             }
             catch (Exception ex)
             {

--- a/BEIMA.Backend/MongoService/MongoConnector.cs
+++ b/BEIMA.Backend/MongoService/MongoConnector.cs
@@ -438,5 +438,10 @@ namespace BEIMA.Backend.MongoService
         }
 
         #endregion
+
+        public FilterDefinition<BsonDocument> GetEqualsFilter(string key, dynamic value)
+        {
+            return Builders<BsonDocument>.Filter.Eq(key, value);
+        }
     }
 }

--- a/BEIMA.Backend/MongoService/MongoConnector.cs
+++ b/BEIMA.Backend/MongoService/MongoConnector.cs
@@ -243,6 +243,16 @@ namespace BEIMA.Backend.MongoService
         }
 
         /// <summary>
+        /// Gets a list of Device BsonDocuments using the passed in filter.
+        /// </summary>
+        /// <param name="filter">The filter to be applied.</param>
+        /// <returns>List of BsonDocuments</returns>
+        public List<BsonDocument> GetFilteredDevices(FilterDefinition<BsonDocument> filter)
+        {
+            return GetFiltered(filter, beimaDb, deviceCollection);
+        }
+
+        /// <summary>
         /// Gets all devices from the "devices" collection.
         /// </summary>
         /// <returns>List of BsonDocuments that was requested</returns>

--- a/BEIMA.Backend/MongoService/MongoConnector.cs
+++ b/BEIMA.Backend/MongoService/MongoConnector.cs
@@ -109,12 +109,12 @@ namespace BEIMA.Backend.MongoService
         }
 
         /// <summary>
-        /// Gets a single BsonDocument from the given database/collection, given an ObjectId.
+        /// Gets a BsonDocument list from the given database/collection, given a BsonDocument filter.
         /// </summary>
         /// <param name="filter">The filter that is being applied.</param>
         /// <param name="dbName">Name of the database.</param>
         /// <param name="collectionName">Name of the collection.</param>
-        /// <returns>BsonDocument that was requested</returns>
+        /// <returns>List of BsonDocuments that were requested</returns>
         private List<BsonDocument> GetFiltered(FilterDefinition<BsonDocument> filter, string dbName, string collectionName)
         {
             CheckIsConnected();

--- a/BEIMA.Backend/MongoService/MongoConnector.cs
+++ b/BEIMA.Backend/MongoService/MongoConnector.cs
@@ -438,10 +438,5 @@ namespace BEIMA.Backend.MongoService
         }
 
         #endregion
-
-        public FilterDefinition<BsonDocument> GetEqualsFilter(string key, dynamic value)
-        {
-            return Builders<BsonDocument>.Filter.Eq(key, value);
-        }
     }
 }

--- a/BEIMA.Backend/MongoService/MongoFilterGenerator.cs
+++ b/BEIMA.Backend/MongoService/MongoFilterGenerator.cs
@@ -21,6 +21,10 @@ namespace BEIMA.Backend.MongoService
         /// <returns>An "equals" filter of type FilterDefinition for BsonDocument</returns>
         public static FilterDefinition<BsonDocument> GetEqualsFilter(string key, dynamic value)
         {
+            if(value == null)
+            {
+                value = BsonNull.Value;
+            }
             return Builders<BsonDocument>.Filter.Eq(key, value);
         }
     }

--- a/BEIMA.Backend/MongoService/MongoFilterGenerator.cs
+++ b/BEIMA.Backend/MongoService/MongoFilterGenerator.cs
@@ -1,0 +1,27 @@
+﻿using MongoDB.Bson;
+using MongoDB.Driver;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BEIMA.Backend.MongoService
+{
+    /// <summary>
+    /// Generates filters to be passed into MongoConnector.GetFiltered methods.
+    /// </summary>
+    public static class MongoFilterGenerator
+    {
+        /// <summary>
+        /// Gets an equals (==) filter given a key and value in a BsonDocument.
+        /// </summary>
+        /// <param name="key">Key of BsonDocument property</param>
+        /// <param name="value">Value of BsonDocument property.</param>
+        /// <returns>An "equals" filter of type FilterDefinition for BsonDocument</returns>
+        public static FilterDefinition<BsonDocument> GetEqualsFilter(string key, dynamic value)
+        {
+            return Builders<BsonDocument>.Filter.Eq(key, value);
+        }
+    }
+}


### PR DESCRIPTION
<!--
These comments inside these brackets will not appear in the pull request.

The pull request should be linked to either:
 - a task (i.e., use 'Closes #TaskID' or 'Resolves #TaskID')
 - a bug (i.e., use 'Closes #BugID' or 'Fixes #BugID')

For more details, see: https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes #337 

This PR implements filtering functionality inside the MongoConnector. GetFilteredDevices was also implemented. 

It also abstracts out the Get method to use the GetFiltered method, since that is basically the same logic. The GetEqualsFilter method was also implemented to make retrieving a filter easier. All it does is return an "equals" filter given a key and value.
