### PR TITLE
Add combine filter functionality in MongoFilterGenerator

### DIFF
--- a/BEIMA.Backend.Test/MongoService/MongoFilterGeneratorTest.cs
+++ b/BEIMA.Backend.Test/MongoService/MongoFilterGeneratorTest.cs
@@ -47,5 +47,25 @@ namespace BEIMA.Backend.Test.MongoService
             Assert.That(filter, Is.InstanceOf(typeof(FilterDefinition<BsonDocument>)));
             Assert.That(doc.GetElement(key).Value, Is.EqualTo(BsonNull.Value));
         }
+
+        [TestCase("key1", "value1", "key2", "value2")]
+        public void TwoFiltersGenerated_CombineFilters_FiltersCombined(string key1, dynamic value1, string key2, dynamic value2)
+        {
+            //Create filters
+            var f1 = MongoFilterGenerator.GetEqualsFilter(key1, value1);
+            var f2 = MongoFilterGenerator.GetEqualsFilter(key2, value2);
+            var combinedFilter = MongoFilterGenerator.CombineFilters(f1, f2);
+
+            //Render the filter as a BsonDocument so we can run tests to make sure the filter is correct
+            var serializerRegistry = BsonSerializer.SerializerRegistry;
+            var documentSerializer = serializerRegistry.GetSerializer<BsonDocument>();
+            var doc = combinedFilter.Render(documentSerializer, serializerRegistry);
+
+            //Ensure filter is correct
+            Assert.That(combinedFilter, Is.Not.Null);
+            Assert.That(combinedFilter, Is.InstanceOf(typeof(FilterDefinition<BsonDocument>)));
+            Assert.That(doc.GetElement(key1).Value?.ToString()?.ToLower(), Is.EqualTo(value1.ToString().ToLower()));
+            Assert.That(doc.GetElement(key2).Value?.ToString()?.ToLower(), Is.EqualTo(value2.ToString().ToLower()));
+        }
     }
 }

--- a/BEIMA.Backend.Test/MongoService/MongoFilterGeneratorTest.cs
+++ b/BEIMA.Backend.Test/MongoService/MongoFilterGeneratorTest.cs
@@ -49,6 +49,7 @@ namespace BEIMA.Backend.Test.MongoService
         }
 
         [TestCase("key1", "value1", "key2", "value2")]
+        [TestCase("aaa", true, "abcdef", 123)]
         public void TwoFiltersGenerated_CombineFilters_FiltersCombined(string key1, dynamic value1, string key2, dynamic value2)
         {
             //Create filters

--- a/BEIMA.Backend/MongoService/MongoFilterGenerator.cs
+++ b/BEIMA.Backend/MongoService/MongoFilterGenerator.cs
@@ -27,5 +27,16 @@ namespace BEIMA.Backend.MongoService
             }
             return Builders<BsonDocument>.Filter.Eq(key, value);
         }
+
+        /// <summary>
+        /// Combines two passed in filters. Will return one filter with the AND operation applied between the two separate filters.
+        /// </summary>
+        /// <param name="f1">The first filter.</param>
+        /// <param name="f2">The second filter.</param>
+        /// <returns>One filter that has the AND operation applied to both filters.</returns>
+        public static FilterDefinition<BsonDocument> CombineFilters(FilterDefinition<BsonDocument> f1, FilterDefinition<BsonDocument> f2)
+        {
+            return Builders<BsonDocument>.Filter.And(f1, f2);
+        }
     }
 }

--- a/BEIMA.Backend/MongoService/MongoFilterGenerator.cs
+++ b/BEIMA.Backend/MongoService/MongoFilterGenerator.cs
@@ -29,14 +29,13 @@ namespace BEIMA.Backend.MongoService
         }
 
         /// <summary>
-        /// Combines two passed in filters. Will return one filter with the AND operation applied between the two separate filters.
+        /// Combines multiple passed in filters. Will return one filter with the AND operation applied between all of the passed in filters.
         /// </summary>
-        /// <param name="f1">The first filter.</param>
-        /// <param name="f2">The second filter.</param>
-        /// <returns>One filter that has the AND operation applied to both filters.</returns>
-        public static FilterDefinition<BsonDocument> CombineFilters(FilterDefinition<BsonDocument> f1, FilterDefinition<BsonDocument> f2)
+        /// <param name="filters">A variable number of filters.</param>
+        /// <returns>One filter that has the AND operation applied to all passed in filters.</returns>
+        public static FilterDefinition<BsonDocument> CombineFilters(params FilterDefinition<BsonDocument>[] filters)
         {
-            return Builders<BsonDocument>.Filter.And(f1, f2);
+            return Builders<BsonDocument>.Filter.And(filters);
         }
     }
 }


### PR DESCRIPTION
<!--
These comments inside these brackets will not appear in the pull request.

The pull request should be linked to either:
 - a task (i.e., use 'Closes #TaskID' or 'Resolves #TaskID')
 - a bug (i.e., use 'Closes #BugID' or 'Fixes #BugID')

For more details, see: https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes #360

This PR adds the ability to combine two separate filters into one filter. Essentially, it performs an AND operation on two filters to combine them together. Now, we will be able to match on multiple properties. 

For example:

username: "user1"
AND
password: "verysecurepassword!"

To use the CombineFilters method, you will need to first create two separate filters using the GetEqualsFilter method. Then, pass the two filters in to the CombineFilters method.
