### PR TITLE
Require valid or null building for devices

### DIFF
--- a/BEIMA.Backend.FT/DeviceFT.cs
+++ b/BEIMA.Backend.FT/DeviceFT.cs
@@ -15,6 +15,7 @@ namespace BEIMA.Backend.FT
     {
         private string? _deviceTypeId;
         private string? _deviceTypeFieldUuid;
+        private string? _buildingId;
 
         [OneTimeSetUp]
         public async Task OneTimeSetUp()
@@ -37,6 +38,18 @@ namespace BEIMA.Backend.FT
                     await TestClient.DeleteDeviceType(deviceType.Id);
                 }
             }
+
+            // Delete all the buildings in the database
+            var buildingList = await TestClient.GetBuildingList();
+            foreach (var building in buildingList)
+            {
+                if (building?.Id is not null)
+                {
+                    await TestClient.DeleteBuilding(building.Id);
+                }
+            }
+
+            // Add back in a test device type
             _deviceTypeId = await TestClient.AddDeviceType(
                 new DeviceTypeAdd
                 {
@@ -49,6 +62,20 @@ namespace BEIMA.Backend.FT
                     },
                 });
             _deviceTypeFieldUuid = (await TestClient.GetDeviceType(_deviceTypeId)).Fields?.Keys.Single();
+
+            // Add back in a test building
+            _buildingId = await TestClient.AddBuilding(
+                new Building
+                {
+                    Name = "Student Union",
+                    Number = "1234",
+                    Notes = "Some building notes.",
+                    Location = new Location
+                    {
+                        Latitude = "0.123",
+                        Longitude = "4.567",
+                    },
+                });
         }
 
         [SetUp]
@@ -102,7 +129,7 @@ namespace BEIMA.Backend.FT
                 },
                 Location = new DeviceLocation
                 {
-                    BuildingId = "111111111111111111111111",
+                    BuildingId = _buildingId,
                     Notes = "Some building notes.",
                     Longitude = "123.001",
                     Latitude = "101.321",
@@ -174,7 +201,7 @@ namespace BEIMA.Backend.FT
                     },
                     Location = new DeviceLocation
                     {
-                        BuildingId = "192830495728394829103986",
+                        BuildingId = _buildingId,
                         Latitude = "101.001",
                         Longitude = "6.234",
                         Notes = "Outside",
@@ -195,7 +222,7 @@ namespace BEIMA.Backend.FT
                     },
                     Location = new DeviceLocation
                     {
-                        BuildingId = "192831695728394829103456",
+                        BuildingId = _buildingId,
                         Latitude = "74.003",
                         Longitude = "138.123",
                         Notes = "Inside",
@@ -216,7 +243,7 @@ namespace BEIMA.Backend.FT
                     },
                     Location = new DeviceLocation
                     {
-                        BuildingId = "192830495728214829103456",
+                        BuildingId = _buildingId,
                         Latitude = "101.989",
                         Longitude = "25.004",
                         Notes = "Above",
@@ -276,7 +303,7 @@ namespace BEIMA.Backend.FT
                 DeviceTypeId = "473830495728394823103456",
                 Location = new DeviceLocation
                 {
-                    BuildingId = "a19830495728394829103986",
+                    BuildingId = _buildingId,
                     Latitude = "111.001",
                     Longitude = "8.242",
                     Notes = "Outside",
@@ -334,7 +361,7 @@ namespace BEIMA.Backend.FT
                 },
                 Location = new DeviceLocation
                 {
-                    BuildingId = "cab830495728394829103986",
+                    BuildingId = _buildingId,
                     Latitude = "11.001",
                     Longitude = "61.234",
                     Notes = "Near",
@@ -362,8 +389,8 @@ namespace BEIMA.Backend.FT
                 updateItem = new DeviceUpdate()
                 {
                     Id = deviceItem.Id,
-                    Manufacturer = deviceItem.Manufacturer, 
-                    ModelNum = deviceItem.ModelNum, 
+                    Manufacturer = deviceItem.Manufacturer,
+                    ModelNum = deviceItem.ModelNum,
                     DeviceTag = deviceItem.DeviceTag,
                     DeviceTypeId = deviceItem.DeviceTypeId,
                     Fields = deviceItem.Fields,

--- a/BEIMA.Backend.Test/DeviceFunctions/AddDeviceTest.cs
+++ b/BEIMA.Backend.Test/DeviceFunctions/AddDeviceTest.cs
@@ -9,6 +9,7 @@ using MongoDB.Bson;
 using Moq;
 using NUnit.Framework;
 using System;
+using System.Net;
 using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
@@ -23,6 +24,9 @@ namespace BEIMA.Backend.Test.DeviceFunctions
         public async Task NoDevice_AddDevice_ReturnsValidId()
         {
             // ARRANGE
+            var building = new Building(new ObjectId("111111111111111111111111"), null, null, null);
+            building.SetLastModified(DateTime.UtcNow, "Anonymous");
+            building.SetLocation(null, null);
             var deviceType = new DeviceType(new ObjectId("12341234abcdabcd43214321"), null, null, null);
             deviceType.SetLastModified(DateTime.UtcNow, "Anonymous");
             deviceType.AddField("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "TestName1");
@@ -30,6 +34,9 @@ namespace BEIMA.Backend.Test.DeviceFunctions
 
             // Setup mock database client.
             Mock<IMongoConnector> mockDb = new Mock<IMongoConnector>();
+            mockDb.Setup(mock => mock.GetBuilding(It.Is<ObjectId>(oid => oid.Equals(new ObjectId("111111111111111111111111")))))
+                  .Returns(building.GetBsonDocument())
+                  .Verifiable();
             mockDb.Setup(mock => mock.GetDeviceType(It.Is<ObjectId>(oid => oid.Equals(new ObjectId("12341234abcdabcd43214321")))))
                   .Returns(deviceType.GetBsonDocument())
                   .Verifiable();
@@ -63,6 +70,7 @@ namespace BEIMA.Backend.Test.DeviceFunctions
             }
 
             // ASSERT
+            Assert.DoesNotThrow(() => mockDb.Verify(mock => mock.GetBuilding(It.IsAny<ObjectId>()), Times.Once));
             Assert.DoesNotThrow(() => mockDb.Verify(mock => mock.GetDeviceType(It.IsAny<ObjectId>()), Times.Once));
             Assert.DoesNotThrow(() => mockDb.Verify(mock => mock.InsertDevice(It.IsAny<BsonDocument>()), Times.Once));
 
@@ -123,6 +131,51 @@ namespace BEIMA.Backend.Test.DeviceFunctions
             Assert.DoesNotThrow(() => mockStorage.Verify(mock => mock.PutFile(It.IsAny<IFormFile>()), Times.Once));
             Assert.DoesNotThrow(() => mockDb.Verify(mock => mock.InsertDevice(It.IsAny<BsonDocument>()), Times.Once));
             Assert.That(ObjectId.TryParse(deviceId, out _), Is.True);
+        }
+
+        [Test]
+        public async Task NoBuilding_AddDevice_ReturnsBuildingNotFound()
+        {
+            // ARRANGE
+
+            // Setup mock database client.
+            Mock<IMongoConnector> mockDb = new Mock<IMongoConnector>();
+            mockDb.Setup(mock => mock.GetBuilding(It.Is<ObjectId>(oid => oid.Equals(new ObjectId("111111111111111111111111")))))
+                  .Returns<BsonDocument>(null)
+                  .Verifiable();
+            MongoDefinition.MongoInstance = mockDb.Object;
+
+            // Setup mock storage client.
+            Mock<IStorageProvider> mockStorage = new Mock<IStorageProvider>();
+            StorageDefinition.StorageInstance = mockStorage.Object;
+
+            // Create request
+            var data = TestData._testDevice;
+            var fileCollection = new FormFileCollection();
+
+            ObjectResult response;
+            using (var fileStream = new ByteArrayContent(TestData._fileBytes).ReadAsStream())
+            {
+                fileCollection.Add(new FormFile(fileStream, 0, fileStream.Length, "files", "file.txt"));
+
+                var request = CreateMultiPartHttpRequest(data, fileCollection);
+                var logger = (new LoggerFactory()).CreateLogger("Testing");
+
+
+                // ACT
+                response = ((ObjectResult)await AddDevice.Run(request, logger));
+            }
+
+            // ASSERT
+            Assert.DoesNotThrow(() => mockDb.Verify(mock => mock.GetBuilding(It.IsAny<ObjectId>()), Times.Once));
+            Assert.DoesNotThrow(() => mockDb.Verify(mock => mock.GetDeviceType(It.IsAny<ObjectId>()), Times.Never));
+            Assert.DoesNotThrow(() => mockDb.Verify(mock => mock.InsertDevice(It.IsAny<BsonDocument>()), Times.Never));
+
+            Assert.DoesNotThrow(() => mockStorage.Verify(mock => mock.PutFile(It.IsAny<IFormFile>()), Times.Never));
+            Assert.That(response, Is.Not.Null);
+            Assert.That(response, Is.TypeOf(typeof(NotFoundObjectResult)));
+            Assert.That(((NotFoundObjectResult)response).StatusCode, Is.EqualTo((int)HttpStatusCode.NotFound));
+            Assert.That(((NotFoundObjectResult)response).Value.ToString(), Is.EqualTo("Building could not be found."));
         }
     }
 }

--- a/BEIMA.Backend.Test/DeviceFunctions/UpdateDeviceTest.cs
+++ b/BEIMA.Backend.Test/DeviceFunctions/UpdateDeviceTest.cs
@@ -106,7 +106,11 @@ namespace BEIMA.Backend.Test.DeviceFunctions
             var testId = "abcdef123456789012345678";
             var device = new Device(new ObjectId(testId), new ObjectId("12341234abcdabcd43214321"), "A-3", "Generic Inc.", "1234", "abcd1234", 2004, "Some notes.");
             device.SetLastModified(DateTime.UtcNow, "Anonymous");
-            device.SetLocation(new ObjectId("111111111111111111111111"), "Some notes.", "123.456", "101.101");
+            device.SetLocation(new ObjectId("622cf00109137c26f913b281"), "Some notes.", "123.456", "101.101");
+
+            var building = new Building(new ObjectId("622cf00109137c26f913b281"), null, null, null);
+            building.SetLastModified(DateTime.UtcNow, "Anonymous");
+            building.SetLocation(null, null);
 
             var deviceType = new DeviceType(new ObjectId("12341234abcdabcd43214321"), null, null, null);
             deviceType.SetLastModified(DateTime.UtcNow, "Anonymous");
@@ -115,9 +119,13 @@ namespace BEIMA.Backend.Test.DeviceFunctions
 
             Mock<IMongoConnector> mockDb = new Mock<IMongoConnector>();
             mockDb.Setup(mock => mock.GetDevice(It.IsAny<ObjectId>()))
-                  .Returns(device.GetBsonDocument());
+                  .Returns(device.GetBsonDocument())
+                  .Verifiable();
             mockDb.Setup(mock => mock.GetDeviceType(It.Is<ObjectId>(oid => oid.Equals(new ObjectId("12341234abcdabcd43214321")))))
                   .Returns(deviceType.GetBsonDocument())
+                  .Verifiable();
+            mockDb.Setup(mock => mock.GetBuilding(It.Is<ObjectId>(oid => oid.Equals(new ObjectId("622cf00109137c26f913b281")))))
+                  .Returns(device.GetBsonDocument())
                   .Verifiable();
             mockDb.Setup(mock => mock.UpdateDevice(It.IsAny<BsonDocument>()))
                   .Returns(device.GetBsonDocument())
@@ -142,7 +150,9 @@ namespace BEIMA.Backend.Test.DeviceFunctions
             var response = await UpdateDevice.Run(request, testId, logger);
 
             // ASSERT
+            Assert.DoesNotThrow(() => mockDb.Verify(mock => mock.GetDevice(It.IsAny<ObjectId>()), Times.Once));
             Assert.DoesNotThrow(() => mockDb.Verify(mock => mock.GetDeviceType(It.IsAny<ObjectId>()), Times.Once));
+            Assert.DoesNotThrow(() => mockDb.Verify(mock => mock.GetBuilding(It.IsAny<ObjectId>()), Times.Once));
             Assert.DoesNotThrow(() => mockDb.Verify(mock => mock.UpdateDevice(It.IsAny<BsonDocument>()), Times.Once));
 
             Assert.IsNotNull(response);

--- a/BEIMA.Backend.Test/TestData.cs
+++ b/BEIMA.Backend.Test/TestData.cs
@@ -1,8 +1,7 @@
 ﻿using BEIMA.Backend.Models;
 using Newtonsoft.Json;
-using System.Net.Http;
-using System.Text;
 using System.Collections.Generic;
+using System.Text;
 
 namespace BEIMA.Backend.Test
 {

--- a/BEIMA.Backend/DeviceFunctions/AddDevice.cs
+++ b/BEIMA.Backend/DeviceFunctions/AddDevice.cs
@@ -54,6 +54,10 @@ namespace BEIMA.Backend.DeviceFunctions
 
                 var reqBuildingId = data.Location.BuildingId;
                 ObjectId? buildingId = reqBuildingId != null ? ObjectId.Parse(reqBuildingId) : null;
+                if (buildingId != null && mongo.GetBuilding((ObjectId)buildingId) is null)
+                {
+                    return new NotFoundObjectResult(Resources.BuildingNotFoundMessage);
+                }
 
                 device.SetLocation(
                     buildingId,


### PR DESCRIPTION
<!--
These comments inside these brackets will not appear in the pull request.

The pull request should be linked to either:
 - a task (i.e., use 'Closes #TaskID' or 'Resolves #TaskID')
 - a bug (i.e., use 'Closes #BugID' or 'Fixes #BugID')

For more details, see: https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes #353

This adds the necessary validation onto the device endpoints to ensure that if a building id is provided, that it actually exists in the database.
