### PR TITLE
Allow year manufactured to be null

### DIFF
--- a/BEIMA.Backend.Test/MongoService/DeviceTest.cs
+++ b/BEIMA.Backend.Test/MongoService/DeviceTest.cs
@@ -184,7 +184,7 @@ namespace BEIMA.Backend.MongoService.Test
             Assert.That(device.Manufacturer, Is.EqualTo(string.Empty));
             Assert.That(device.ModelNum, Is.EqualTo(string.Empty));
             Assert.That(device.SerialNum, Is.EqualTo(string.Empty));
-            Assert.That(device.YearManufactured, Is.EqualTo(-1));
+            Assert.That(device.YearManufactured, Is.Null);
             Assert.That(device.Notes, Is.EqualTo(string.Empty));
         }
 

--- a/BEIMA.Backend.Test/TestData.cs
+++ b/BEIMA.Backend.Test/TestData.cs
@@ -147,7 +147,8 @@ namespace BEIMA.Backend.Test
                     Latitude = "1231232",
                     Longitude = "123213213"
                 },
-                DeletedFiles = new List<string>()
+                YearManufactured = 1880,
+                DeletedFiles = new List<string>(),
             };
             request.DeletedFiles.Add("fileOneUid");
             request.DeletedFiles.Add("fileTwoUid");
@@ -169,6 +170,7 @@ namespace BEIMA.Backend.Test
                     { "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "TestValue1"},
                     { "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", "TestValue2"}
                 },
+                YearManufactured = 1880,
                 DeletedFiles = new List<string>()
             };
             return JsonConvert.SerializeObject(request);

--- a/BEIMA.Backend/Models/Requests.cs
+++ b/BEIMA.Backend/Models/Requests.cs
@@ -12,7 +12,7 @@ namespace BEIMA.Backend.Models
         public string Manufacturer { get; set; }
         public string ModelNum { get; set; }
         public string SerialNum { get; set; }
-        public int YearManufactured { get; set; }
+        public int? YearManufactured { get; set; }
         public string Notes { get; set; }
         public DeviceLocation Location { get; set; } = new DeviceLocation();
         public Dictionary<string, string> Fields { get; set; } = new Dictionary<string, string>();
@@ -28,7 +28,7 @@ namespace BEIMA.Backend.Models
         public string Manufacturer { get; set; }
         public string ModelNum { get; set; }
         public string SerialNum { get; set; }
-        public int YearManufactured { get; set; }
+        public int? YearManufactured { get; set; }
         public string Notes { get; set; }
         public DeviceLocation Location { get; set; } = new DeviceLocation();
         public Dictionary<string, string> Fields { get; set; } = new Dictionary<string, string>();

--- a/BEIMA.Backend/MongoService/Device.cs
+++ b/BEIMA.Backend/MongoService/Device.cs
@@ -125,7 +125,7 @@ namespace BEIMA.Backend.MongoService
             Manufacturer = manufacturer ?? string.Empty;
             ModelNum = modelNum ?? string.Empty;
             SerialNum = serialNum ?? string.Empty;
-            YearManufactured = yearManufactured ?? -1;
+            YearManufactured = yearManufactured;
             Notes = notes ?? string.Empty;
             Location = new DeviceLocation();
             LastModified = new DeviceLastModified();


### PR DESCRIPTION
<!--
These comments inside these brackets will not appear in the pull request.

The pull request should be linked to either:
 - a task (i.e., use 'Closes #TaskID' or 'Resolves #TaskID')
 - a bug (i.e., use 'Closes #BugID' or 'Fixes #BugID')

For more details, see: https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes #299

This fixes the issue where we could not send an empty/null year manufactured value to the device endpoints. This was because the request parser was using regular int types instead of nullable int types. We should now be able to send empty/null year manufactured values.
