### PR TITLE
358 Bug adding photo null exception

### DIFF
--- a/BEIMA.Backend.Test/StorageService/AzureStorageProviderTest.cs
+++ b/BEIMA.Backend.Test/StorageService/AzureStorageProviderTest.cs
@@ -18,8 +18,8 @@ namespace BEIMA.Backend.Test.StorageService
         [Test]
         public void SmokeTest()
         {
-            Assert.IsNotNull(_storage);
-            Assert.IsInstanceOf(typeof(AzureStorageProvider), _storage);
+            Assert.That(_storage, Is.Not.Null);
+            Assert.That(_storage, Is.InstanceOf(typeof(AzureStorageProvider)));
         }
 
         [Test]

--- a/BEIMA.Backend.Test/StorageService/AzureStorageProviderTest.cs
+++ b/BEIMA.Backend.Test/StorageService/AzureStorageProviderTest.cs
@@ -18,8 +18,8 @@ namespace BEIMA.Backend.Test.StorageService
         [Test]
         public void SmokeTest()
         {
-            Assert.That(_storage, Is.Not.Null);
-            Assert.That(_storage, Is.InstanceOf(typeof(AzureStorageProvider)));
+            Assert.IsNotNull(_storage);
+            Assert.IsInstanceOf(typeof(AzureStorageProvider), _storage);
         }
 
         [Test]
@@ -57,6 +57,16 @@ namespace BEIMA.Backend.Test.StorageService
 
             //Act
             var stream = await _storage.GetFileStream(fileUid);
+
+            //Assert
+            Assert.That(stream, Is.Null);
+        }
+
+        [Test]
+        public async Task NullFileUid_GetFileStream_StreamNotExists()
+        {
+            //Act
+            var stream = await _storage.GetFileStream(null);
 
             //Assert
             Assert.That(stream, Is.Null);
@@ -101,6 +111,16 @@ namespace BEIMA.Backend.Test.StorageService
         }
 
         [Test]
+        public async Task NullFileUid_GetPresignedUrl_PresignedUrlNotExists()
+        {
+            //Act
+            var url = await _storage.GetPresignedURL(null);
+
+            //Assert
+            Assert.That(url, Is.Null);
+        }
+
+        [Test]
         public async Task FileNotExists_PutFile_FileUidExists()
         {
             //Arrange
@@ -121,6 +141,16 @@ namespace BEIMA.Backend.Test.StorageService
 
             //Assert
             Assert.That(fileUid, Is.Not.Null);
+        }
+
+        [Test]
+        public async Task NullFile_PutFile_FileUidExists()
+        {
+            //Act
+            var fileUid = await _storage.PutFile(null);
+
+            //Assert
+            Assert.That(fileUid, Is.Null);
         }
 
         [Test]
@@ -166,6 +196,17 @@ namespace BEIMA.Backend.Test.StorageService
             //Assert
             Assert.That(result, Is.True);
             Assert.That(postDelExists, Is.False);
+        }
+
+        [Test]
+        public async Task Null_DeleteObject_DeletedTrue()
+        {
+            //Act
+            var result = await _storage.DeleteFile(null);
+
+            //Assert
+            Assert.That(result, Is.True);
+
         }
     }
 }

--- a/BEIMA.Backend.Test/StorageService/MinioStorageProviderTest.cs
+++ b/BEIMA.Backend.Test/StorageService/MinioStorageProviderTest.cs
@@ -63,6 +63,16 @@ namespace BEIMA.Backend.Test.StorageService
         }
 
         [Test]
+        public async Task NullFileUid_GetFileStream_StreamNotExists()
+        {
+            //Act
+            var stream = await _storage.GetFileStream(null);
+
+            //Assert
+            Assert.That(stream, Is.Null);
+        }
+
+        [Test]
         public async Task FileExists_GetPresignedUrl_PresignedUrlExists()
         {
             //Arrange
@@ -101,6 +111,16 @@ namespace BEIMA.Backend.Test.StorageService
         }
 
         [Test]
+        public async Task NullFileUid_GetPresignedUrl_PresignedUrlNotExists()
+        {
+            //Act
+            var url = await _storage.GetPresignedURL(null);
+
+            //Assert
+            Assert.That(url, Is.Null);
+        }
+
+        [Test]
         public async Task FileNotExists_PutFile_FileUidExists()
         {
             //Arrange
@@ -121,6 +141,16 @@ namespace BEIMA.Backend.Test.StorageService
 
             //Assert
             Assert.That(fileUid, Is.Not.Null);
+        }
+
+        [Test]
+        public async Task NullFile_PutFile_FileUidExists()
+        {
+            //Act
+            var fileUid = await _storage.PutFile(null);
+
+            //Assert
+            Assert.That(fileUid, Is.Null);
         }
 
         [Test]
@@ -166,6 +196,17 @@ namespace BEIMA.Backend.Test.StorageService
             //Assert
             Assert.That(result, Is.True);
             Assert.That(postDelExists, Is.False);
+        }
+
+        [Test]
+        public async Task Null_DeleteObject_DeletedTrue()
+        {
+            //Act
+            var result = await _storage.DeleteFile(null);
+
+            //Assert
+            Assert.That(result, Is.True);
+
         }
     }
 }

--- a/BEIMA.Backend.Test/StorageService/MinioStorageProviderTest.cs
+++ b/BEIMA.Backend.Test/StorageService/MinioStorageProviderTest.cs
@@ -18,8 +18,8 @@ namespace BEIMA.Backend.Test.StorageService
         [Test]
         public void SmokeTest()
         {
-            Assert.IsNotNull(_storage);
-            Assert.IsInstanceOf(typeof(MinioStorageProvider), _storage);
+            Assert.That(_storage, Is.Not.Null);
+            Assert.That(_storage, Is.InstanceOf(typeof(MinioStorageProvider)));
         }
 
         [Test]

--- a/BEIMA.Backend.Test/StorageService/StorageProviderTest.cs
+++ b/BEIMA.Backend.Test/StorageService/StorageProviderTest.cs
@@ -73,6 +73,19 @@ namespace BEIMA.Backend.Test.StorageService
         }
 
         [Test]
+        public async Task NullFileUid_GetFileStream_StreamNotExists()
+        {
+            //Arrange
+            var _storage = StorageProvider.Instance;
+
+            //Act
+            var stream = await _storage.GetFileStream(null);
+
+            //Assert
+            Assert.That(stream, Is.Null);
+        }
+
+        [Test]
         public async Task FileExists_GetPresignedUrl_PresignedUrlExists()
         {
             //Arrange
@@ -104,11 +117,23 @@ namespace BEIMA.Backend.Test.StorageService
         {
             //Arrange
             var _storage = StorageProvider.Instance;
-
             var fileUid = Guid.NewGuid().ToString();
 
             //Act
             var url = await _storage.GetPresignedURL(fileUid);
+
+            //Assert
+            Assert.That(url, Is.Null);
+        }
+
+        [Test]
+        public async Task NullFileUid_GetPresignedUrl_PresignedUrlNotExists()
+        {
+            //Arrange
+            var _storage = StorageProvider.Instance;
+
+            //Act
+            var url = await _storage.GetPresignedURL(null);
 
             //Assert
             Assert.That(url, Is.Null);
@@ -137,6 +162,19 @@ namespace BEIMA.Backend.Test.StorageService
 
             //Assert
             Assert.That(fileUid, Is.Not.Null);
+        }
+
+        [Test]
+        public async Task NullFile_PutFile_FileUidExists()
+        {
+            //Arrange
+            var _storage = StorageProvider.Instance;
+
+            //Act
+            var fileUid = await _storage.PutFile(null);
+
+            //Assert
+            Assert.That(fileUid, Is.Null);
         }
 
         [Test]
@@ -176,7 +214,6 @@ namespace BEIMA.Backend.Test.StorageService
         {
             //Arrange
             var _storage = StorageProvider.Instance;
-
             var fileUid = Guid.NewGuid().ToString();
 
             //Act
@@ -186,6 +223,20 @@ namespace BEIMA.Backend.Test.StorageService
             //Assert
             Assert.That(result, Is.True);
             Assert.That(postDelExists, Is.False);
+        }
+
+        [Test]
+        public async Task Null_DeleteObject_DeletedTrue()
+        {
+            //Arrange
+            var _storage = StorageProvider.Instance;
+
+            //Act
+            var result = await _storage.DeleteFile(null);
+
+            //Assert
+            Assert.That(result, Is.True);
+
         }
     }
 }

--- a/BEIMA.Backend/DeviceFunctions/UpdateDevice.cs
+++ b/BEIMA.Backend/DeviceFunctions/UpdateDevice.cs
@@ -117,7 +117,7 @@ namespace BEIMA.Backend.DeviceFunctions
 
             // Check if there is a new photo to replace the old one
             var updatePhoto = reqForm.Files.Any(file => file.Name == "photo");
-            if (updatePhoto && device.Photo != null)
+            if (updatePhoto && device.Photo != null && device.Photo.FileUid != null)
             {
                 filesToDelete.Add(device.Photo.FileUid);
             }

--- a/BEIMA.Backend/StorageService/AzureStorageProvider.cs
+++ b/BEIMA.Backend/StorageService/AzureStorageProvider.cs
@@ -35,6 +35,11 @@ namespace BEIMA.Backend.StorageService
         /// <returns>Uid of the file created or null if request failed</returns>
         public async Task<string> PutFile(IFormFile file)
         {
+            if (file == null)
+            {
+                return null;
+            }
+
             try
             {
                 string fileUid = null;
@@ -67,6 +72,11 @@ namespace BEIMA.Backend.StorageService
         /// <returns>Presigned url or null if request failed</returns>
         public async Task<string> GetPresignedURL(string fileUid)
         {
+            if (string.IsNullOrEmpty(fileUid))
+            {
+                return null;
+            }
+
             try
             {
                 var exists = await GetFileExists(fileUid);
@@ -100,6 +110,11 @@ namespace BEIMA.Backend.StorageService
         /// <returns>Memorystream of the target file or null if request failed</returns>
         public async Task<MemoryStream> GetFileStream(string fileUid)
         {
+            if (string.IsNullOrEmpty(fileUid))
+            {
+                return null;
+            }
+
             try
             {
                 var client = containerClient.GetBlobClient(fileUid);
@@ -122,6 +137,11 @@ namespace BEIMA.Backend.StorageService
         /// <returns>True if target file exists or false if it doesn't</returns>
         public async Task<bool> GetFileExists(string fileUid)
         {
+            if (string.IsNullOrEmpty(fileUid))
+            {
+                return false;
+            }
+
             try
             {
                 var client = containerClient.GetBlobClient(fileUid);
@@ -140,6 +160,11 @@ namespace BEIMA.Backend.StorageService
         /// <returns>True if target file was deleted or false if request failed</returns>
         public async Task<bool> DeleteFile(string fileUid)
         {
+            if (string.IsNullOrEmpty(fileUid))
+            {
+                return true;
+            }
+
             try
             {
                 var exists = await GetFileExists(fileUid);

--- a/BEIMA.Backend/StorageService/MinioStorageProvider.cs
+++ b/BEIMA.Backend/StorageService/MinioStorageProvider.cs
@@ -35,6 +35,11 @@ namespace BEIMA.Backend.StorageService
         /// <returns>Uid of the file created or null if request failed</returns>
         public async Task<string> PutFile(IFormFile file)
         {
+            if (file == null)
+            {
+                return null;
+            }
+
             try
             {
                 string fileUid = null;
@@ -70,6 +75,11 @@ namespace BEIMA.Backend.StorageService
         /// <returns>Presigned url or null if request failed</returns>
         public async Task<string> GetPresignedURL(string fileUid)
         {
+            if (string.IsNullOrEmpty(fileUid))
+            {
+                return null;
+            }
+
             try
             {
                 var exists = await GetFileExists(fileUid);
@@ -97,6 +107,11 @@ namespace BEIMA.Backend.StorageService
         /// <returns>Memorystream of the target file or null if request failed</returns>
         public async Task<MemoryStream> GetFileStream(string fileUid)
         {
+            if (string.IsNullOrEmpty(fileUid))
+            {
+                return null;
+            }
+
             try
             {
                 MemoryStream ms = new MemoryStream();
@@ -125,6 +140,11 @@ namespace BEIMA.Backend.StorageService
         /// <returns>True if target file exists or false if it doesn't</returns>
         public async Task<bool> GetFileExists(string fileUid)
         {
+            if (string.IsNullOrEmpty(fileUid))
+            {
+                return false;
+            }
+
             var statArgs = new StatObjectArgs()
                     .WithBucket(bucket)
                     .WithObject(fileUid);
@@ -147,6 +167,11 @@ namespace BEIMA.Backend.StorageService
         /// <returns>True if target file was deleted or false if request failed</returns>
         public async Task<bool> DeleteFile(string fileUid)
         {
+            if (string.IsNullOrEmpty(fileUid))
+            {
+                return true;
+            }
+
             try
             {
                 var delArgs = new RemoveObjectArgs()


### PR DESCRIPTION
<!--
These comments inside these brackets will not appear in the pull request.

The pull request should be linked to either:
 - a task (i.e., use 'Closes #TaskID' or 'Resolves #TaskID')
 - a bug (i.e., use 'Closes #BugID' or 'Fixes #BugID')

For more details, see: https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes #358 

After investigation the delete(null) works fine when using the underlying azure methods, but would throw an exception when using the underlying minio methods. To remedy this, null/empty string validation was added to all of the storage provider methods. 
