### PR TITLE
User POST - AddUser

### DIFF
--- a/BEIMA.Backend.FT/BeimaClient.cs
+++ b/BEIMA.Backend.FT/BeimaClient.cs
@@ -359,6 +359,22 @@ namespace BEIMA.Backend.FT
 
         #endregion Building Requests
 
+        #region User Requests
+
+        /// <summary>
+        /// Sends a user post request to the BEIMA api.
+        /// </summary>
+        /// <param name="user">The user to add.</param>
+        /// <returns>The id of the new user.</returns>
+        public async Task<string> AddUser(User user)
+        {
+            var response = await SendRequest("api/user", HttpVerb.POST, user);
+            var content = await response.Content.ReadAsStringAsync();
+            return JsonConvert.DeserializeObject<string>(content);
+        }
+
+        #endregion
+
         /// <summary>
         /// Disposes the http client.
         /// </summary>

--- a/BEIMA.Backend.FT/TestObjects.cs
+++ b/BEIMA.Backend.FT/TestObjects.cs
@@ -162,6 +162,9 @@ namespace BEIMA.Backend.FT
 
             [JsonProperty(PropertyName = "role")]
             public string? Role { get; set; }
+
+            [JsonProperty(PropertyName = "lastModified")]
+            public LastModified? LastModified { get; set; }
         }
 
         public class Location

--- a/BEIMA.Backend.FT/TestObjects.cs
+++ b/BEIMA.Backend.FT/TestObjects.cs
@@ -143,6 +143,27 @@ namespace BEIMA.Backend.FT
             public LastModified? LastModified { get; set; }
         }
 
+        public class User
+        {
+            [JsonProperty(PropertyName = "_id")]
+            public string? Id { get; set; }
+
+            [JsonProperty(PropertyName = "username")]
+            public string? Username { get; set; }
+
+            [JsonProperty(PropertyName = "password")]
+            public string? Password { get; set; }
+
+            [JsonProperty(PropertyName = "firstName")]
+            public string? FirstName { get; set; }
+
+            [JsonProperty(PropertyName = "lastName")]
+            public string? LastName { get; set; }
+
+            [JsonProperty(PropertyName = "role")]
+            public string? Role { get; set; }
+        }
+
         public class Location
         {
             [JsonProperty(PropertyName = "latitude")]

--- a/BEIMA.Backend.FT/UserFT.cs
+++ b/BEIMA.Backend.FT/UserFT.cs
@@ -1,0 +1,33 @@
+﻿using MongoDB.Bson;
+using NUnit.Framework;
+using System.Threading.Tasks;
+using static BEIMA.Backend.FT.TestObjects;
+
+namespace BEIMA.Backend.FT
+{
+    [TestFixture]
+    public class UserFT : FunctionalTestBase
+    {
+        [Test]
+        public async Task UserNotInDatabase_AddUser_CreatesNewUser()
+        {
+            // ARRANGE
+            var user = new User
+            {
+                Username = "user.name",
+                Password = "Abcdefg12345!",
+                FirstName = "Alex",
+                LastName = "Smith",
+                Role = "user"
+            };
+
+            // ACT
+            var responseId = await TestClient.AddUser(user);
+
+            // ASSERT
+            Assert.That(responseId, Is.Not.Null);
+            Assert.That(ObjectId.TryParse(responseId, out _), Is.True);
+            //TODO: add more in depth testing when get endpoint is implemented.
+        }
+    }
+}

--- a/BEIMA.Backend.Test/TestData.cs
+++ b/BEIMA.Backend.Test/TestData.cs
@@ -100,6 +100,15 @@ namespace BEIMA.Backend.Test
                 "}" +
             "}";
 
+        public const string _testUser =
+            "{" +
+                "\"username\": \"user.name\"," +
+                "\"password\": \"Abcdefg12345!\"," +
+                "\"firstName\": \"Alex\"," +
+                "\"lastName\": \"Smith\"," +
+                "\"role\": \"user\"" +
+            "}";
+
         public static readonly string _testAddDeviceNoLocation = GenerateAddDeviceNoLocation();
         public static readonly string _testUpdateDeviceDeleteFiles = GenerateUpdateDeviceRequest();
         public static readonly string _testUpdateDeviceNoLocation = GenerateUpdateDeviceNoLocationRequest();

--- a/BEIMA.Backend.Test/UserFunctions/AddUserTest.cs
+++ b/BEIMA.Backend.Test/UserFunctions/AddUserTest.cs
@@ -1,0 +1,40 @@
+﻿using BEIMA.Backend.UserFunctions;
+using BEIMA.Backend.MongoService;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using MongoDB.Bson;
+using Moq;
+using NUnit.Framework;
+using System.Threading.Tasks;
+using static BEIMA.Backend.Test.RequestFactory;
+
+namespace BEIMA.Backend.Test.UserFunctions
+{
+    [TestFixture]
+    public class AddUserTest : UnitTestBase
+    {
+        [Test]
+        public async Task NoUser_AddUser_ReturnsValidId()
+        {
+            // ARRANGE
+            // Setup mock database client.
+            Mock<IMongoConnector> mockDb = new Mock<IMongoConnector>();
+            mockDb.Setup(mock => mock.InsertBuilding(It.IsAny<BsonDocument>()))
+                  .Returns(ObjectId.GenerateNewId())
+                  .Verifiable();
+            MongoDefinition.MongoInstance = mockDb.Object;
+
+            // Create request
+            var body = TestData._testUser;
+            var request = CreateHttpRequest(RequestMethod.POST, body: body);
+            var logger = (new LoggerFactory()).CreateLogger("Testing");
+
+            // ACT
+            var userId = ((ObjectResult)await AddUser.Run(request, logger)).Value?.ToString();
+
+            // ASSERT
+            Assert.IsNotNull(userId);
+            Assert.That(ObjectId.TryParse(userId, out _), Is.True);
+        }
+    }
+}

--- a/BEIMA.Backend.Test/UserFunctions/AddUserTest.cs
+++ b/BEIMA.Backend.Test/UserFunctions/AddUserTest.cs
@@ -19,7 +19,7 @@ namespace BEIMA.Backend.Test.UserFunctions
             // ARRANGE
             // Setup mock database client.
             Mock<IMongoConnector> mockDb = new Mock<IMongoConnector>();
-            mockDb.Setup(mock => mock.InsertBuilding(It.IsAny<BsonDocument>()))
+            mockDb.Setup(mock => mock.InsertUser(It.IsAny<BsonDocument>()))
                   .Returns(ObjectId.GenerateNewId())
                   .Verifiable();
             MongoDefinition.MongoInstance = mockDb.Object;

--- a/BEIMA.Backend/BEIMA.Backend.csproj
+++ b/BEIMA.Backend/BEIMA.Backend.csproj
@@ -10,6 +10,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Azure.Storage.Blobs" Version="12.10.0" />
+    <PackageReference Include="BCrypt.Net-Next" Version="4.0.3" />
     <PackageReference Include="JWT" Version="8.9.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />

--- a/BEIMA.Backend/Models/Requests.cs
+++ b/BEIMA.Backend/Models/Requests.cs
@@ -57,6 +57,18 @@ namespace BEIMA.Backend.Models
     }
 
     /// <summary>
+    /// Object representation of the data object in a user request
+    /// </summary>
+    public class UserRequest
+    {
+        public string Username { get; set; }
+        public string Password { get; set; }
+        public string FirstName { get; set; }
+        public string LastName { get; set; }
+        public string Role { get; set; }
+    }
+
+    /// <summary>
     /// Location Object representation of location field in an add building request
     /// </summary>
     public class Location

--- a/BEIMA.Backend/MongoService/IMongoConnector.cs
+++ b/BEIMA.Backend/MongoService/IMongoConnector.cs
@@ -111,5 +111,12 @@ namespace BEIMA.Backend.MongoService
         /// <param name="doc">BsonDocument containing the updated BsonDocument.</param>
         /// <returns>The updated BsonDocument, or null if nothing was updated.</returns>
         public BsonDocument UpdateBuilding(BsonDocument doc);
+
+        /// <summary>
+        /// Inserts a user into the "users" collection
+        /// </summary>
+        /// <param name="doc">BsonDocument that contains the fully formed user document</param>
+        /// <returns>ObjectId of the newly inserted object if successful, null if failed</returns>
+        public ObjectId? InsertUser(BsonDocument doc);
     }
 }

--- a/BEIMA.Backend/Resources.Designer.cs
+++ b/BEIMA.Backend/Resources.Designer.cs
@@ -115,6 +115,15 @@ namespace BEIMA.Backend {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to An internal server error has occurred..
+        /// </summary>
+        internal static string InternalServerErrorMessage {
+            get {
+                return ResourceManager.GetString("InternalServerErrorMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Invalid Id..
         /// </summary>
         internal static string InvalidIdMessage {

--- a/BEIMA.Backend/Resources.resx
+++ b/BEIMA.Backend/Resources.resx
@@ -141,6 +141,10 @@
     <value>Device type could not be found.</value>
     <comment>Error message for when trying to access a device type that could not be found in the database.</comment>
   </data>
+  <data name="InternalServerErrorMessage" xml:space="preserve">
+    <value>An internal server error has occurred.</value>
+    <comment>Error message when a general internal server error has occurred. This is currently being used for when a MongoConnector operation has failed.</comment>
+  </data>
   <data name="InvalidIdMessage" xml:space="preserve">
     <value>Invalid Id.</value>
     <comment>Error message for an invalid id.</comment>

--- a/BEIMA.Backend/Rules.cs
+++ b/BEIMA.Backend/Rules.cs
@@ -87,7 +87,7 @@ namespace BEIMA.Backend
         /// <param name="message">The error message for a failed validation.</param>
         /// <param name="httpStatusCode">The status code for a failed validation.</param>
         /// <returns>True if the user is valid, otherwise false.</returns>
-        public static bool IsBuildingValid(User user, out string message, out HttpStatusCode httpStatusCode)
+        public static bool IsUserValid(User user, out string message, out HttpStatusCode httpStatusCode)
         {
             bool isValid = true;
             message = string.Empty;

--- a/BEIMA.Backend/Rules.cs
+++ b/BEIMA.Backend/Rules.cs
@@ -79,5 +79,28 @@ namespace BEIMA.Backend
 
             return isValid;
         }
+
+        /// <summary>
+        /// Verifies that a given user has valid properties.
+        /// </summary>
+        /// <param name="user">User to verify.</param>
+        /// <param name="message">The error message for a failed validation.</param>
+        /// <param name="httpStatusCode">The status code for a failed validation.</param>
+        /// <returns>True if the user is valid, otherwise false.</returns>
+        public static bool IsBuildingValid(User user, out string message, out HttpStatusCode httpStatusCode)
+        {
+            bool isValid = true;
+            message = string.Empty;
+            httpStatusCode = HttpStatusCode.OK;
+
+            if (user is null)
+            {
+                message = "User is null.";
+                httpStatusCode = HttpStatusCode.BadRequest;
+                isValid = false;
+            }
+
+            return isValid;
+        }
     }
 }

--- a/BEIMA.Backend/UserFunctions/AddUser.cs
+++ b/BEIMA.Backend/UserFunctions/AddUser.cs
@@ -12,6 +12,7 @@ using MongoDB.Bson;
 using BEIMA.Backend.Models;
 using System.Net;
 using System.Web.Http;
+using BCryptNet = BCrypt.Net.BCrypt;
 
 namespace BEIMA.Backend.UserFunctions
 {
@@ -38,9 +39,10 @@ namespace BEIMA.Backend.UserFunctions
             {
                 string requestBody = await new StreamReader(req.Body).ReadToEndAsync();
                 var data = JsonConvert.DeserializeObject<UserRequest>(requestBody);
+                var passwordHash = BCryptNet.HashPassword(data.Password);
                 user = new User(ObjectId.GenerateNewId(),
                                         data.Username,
-                                        data.Password,
+                                        passwordHash,
                                         data.FirstName,
                                         data.LastName,
                                         data.Role);

--- a/BEIMA.Backend/UserFunctions/AddUser.cs
+++ b/BEIMA.Backend/UserFunctions/AddUser.cs
@@ -67,7 +67,9 @@ namespace BEIMA.Backend.UserFunctions
             //InsertUser returned a null result, meaning it failed, so send a 500 error
             if(id == null)
             {
-                return new InternalServerErrorResult();
+                var response = new ObjectResult("Internal server error");
+                response.StatusCode = StatusCodes.Status500InternalServerError;
+                return response;
             }
 
             return new OkObjectResult(id.ToString());

--- a/BEIMA.Backend/UserFunctions/AddUser.cs
+++ b/BEIMA.Backend/UserFunctions/AddUser.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Azure.WebJobs;
+using Microsoft.Azure.WebJobs.Extensions.Http;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+using BEIMA.Backend.MongoService;
+using MongoDB.Bson;
+using BEIMA.Backend.Models;
+using System.Net;
+
+namespace BEIMA.Backend.UserFunctions
+{
+    /// <summary>
+    /// Handles a request to add a single user.
+    /// </summary>
+    public static class AddUser
+    {
+        /// <summary>
+        /// Handles user create request.
+        /// </summary>
+        /// <param name="req">The http request.</param>
+        /// <param name="log">The logger to log to.</param>
+        /// <returns>An http response containing the id of the newly created user.</returns>
+        [FunctionName("AddUser")]
+        public static async Task<IActionResult> Run(
+            [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "user")] HttpRequest req,
+            ILogger log)
+        {
+            log.LogInformation("C# HTTP trigger function processed a user post request.");
+
+            User user;
+            try
+            {
+                string requestBody = await new StreamReader(req.Body).ReadToEndAsync();
+                var data = JsonConvert.DeserializeObject<UserRequest>(requestBody);
+                user = new User(ObjectId.GenerateNewId(),
+                                        data.Name,
+                                        data.Number,
+                                        data.Notes);
+                user.SetLocation(data.Location.Latitude, data.Location.Longitude);
+            }
+            catch (Exception)
+            {
+                return new BadRequestObjectResult(Resources.CouldNotParseBody);
+            }
+            // TODO: Use actual user.
+            user.SetLastModified(DateTime.UtcNow, "Anonymous");
+
+            string message;
+            HttpStatusCode statusCode;
+            if (!Rules.IsUserValid(user, out message, out statusCode))
+            {
+                var response = new ObjectResult(message);
+                response.StatusCode = (int)statusCode;
+                return response;
+            }
+
+            var mongo = MongoDefinition.MongoInstance;
+            var id = mongo.InsertUser(user.GetBsonDocument());
+
+            return new OkObjectResult(id.ToString());
+        }
+    }
+}

--- a/BEIMA.Backend/UserFunctions/AddUser.cs
+++ b/BEIMA.Backend/UserFunctions/AddUser.cs
@@ -11,7 +11,6 @@ using BEIMA.Backend.MongoService;
 using MongoDB.Bson;
 using BEIMA.Backend.Models;
 using System.Net;
-using System.Web.Http;
 using BCryptNet = BCrypt.Net.BCrypt;
 
 namespace BEIMA.Backend.UserFunctions

--- a/BEIMA.Backend/UserFunctions/AddUser.cs
+++ b/BEIMA.Backend/UserFunctions/AddUser.cs
@@ -11,6 +11,7 @@ using BEIMA.Backend.MongoService;
 using MongoDB.Bson;
 using BEIMA.Backend.Models;
 using System.Net;
+using System.Web.Http;
 
 namespace BEIMA.Backend.UserFunctions
 {
@@ -62,6 +63,12 @@ namespace BEIMA.Backend.UserFunctions
 
             var mongo = MongoDefinition.MongoInstance;
             var id = mongo.InsertUser(user.GetBsonDocument());
+
+            //InsertUser returned a null result, meaning it failed, so send a 500 error
+            if(id == null)
+            {
+                return new InternalServerErrorResult();
+            }
 
             return new OkObjectResult(id.ToString());
         }

--- a/BEIMA.Backend/UserFunctions/AddUser.cs
+++ b/BEIMA.Backend/UserFunctions/AddUser.cs
@@ -68,7 +68,7 @@ namespace BEIMA.Backend.UserFunctions
             //InsertUser returned a null result, meaning it failed, so send a 500 error
             if(id == null)
             {
-                var response = new ObjectResult("Internal server error");
+                var response = new ObjectResult(Resources.InternalServerErrorMessage);
                 response.StatusCode = StatusCodes.Status500InternalServerError;
                 return response;
             }

--- a/BEIMA.Backend/UserFunctions/AddUser.cs
+++ b/BEIMA.Backend/UserFunctions/AddUser.cs
@@ -38,10 +38,11 @@ namespace BEIMA.Backend.UserFunctions
                 string requestBody = await new StreamReader(req.Body).ReadToEndAsync();
                 var data = JsonConvert.DeserializeObject<UserRequest>(requestBody);
                 user = new User(ObjectId.GenerateNewId(),
-                                        data.Name,
-                                        data.Number,
-                                        data.Notes);
-                user.SetLocation(data.Location.Latitude, data.Location.Longitude);
+                                        data.Username,
+                                        data.Password,
+                                        data.FirstName,
+                                        data.LastName,
+                                        data.Role);
             }
             catch (Exception)
             {


### PR DESCRIPTION
<!--
These comments inside these brackets will not appear in the pull request.

The pull request should be linked to either:
 - a task (i.e., use 'Closes #TaskID' or 'Resolves #TaskID')
 - a bug (i.e., use 'Closes #BugID' or 'Fixes #BugID')

For more details, see: https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes #302 
Closes #378

This PR implements the AddUser endpoint. It also implements a password hashing package called BCrypt.Net. This uses the bcrypt algorithm, and it is generally accepted as a secure password hashing algorithm. This package was chosen because it is widely used, and it makes password hashing extremely easy as shown in the documentation here: https://github.com/BcryptNet/bcrypt.net

Using statement: 
`using BCryptNet = BCrypt.Net.BCrypt;`

To hash passwords:
`string passwordHash = BCryptNet.HashPassword(data.Password);`

To check a plain text password against a hashed password:
`bool passwordCorrect = BCrypt.Verify("plaintextPassword1!", passwordHash);`


Note on EnhancedHashPassword and EnhancedVerify methods in BCrypt.Net:

A conscious decision was made to not use the "Enhanced" versions of these methods. According to this article below, it is insecure to pre-hash passwords in the manner that EnhancedHashPassword does.

> An alternative approach is to pre-hash the user-supplied password with a fast algorithm such as SHA-256, and then to hash the resulting hash with bcrypt (i.e., bcrypt(base64(hmac-sha256(data:$password, key:$pepper)), $salt, $cost)). This is a dangerous (but common) practice that should be avoided due to [password shucking](https://www.youtube.com/watch?v=OQD3qDYMyYQ) and other issues when [combining bcrypt with other hash functions](https://blog.ircmaxell.com/2015/03/security-issue-combining-bcrypt-with.html).

From: https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html