### PR TITLE
Task#159 add device empty field warning

### DIFF
--- a/BEIMA.Client/src/pages/Devices/AddDevicePage.js
+++ b/BEIMA.Client/src/pages/Devices/AddDevicePage.js
@@ -230,7 +230,7 @@ const AddDevicePage = () => {
         let jsonKey = convertToDbFriendly(formName);
         
         if(formFields[i].value.length === 0){
-          warnings.push(`${formName} field is empty<br/>`);
+          warnings.push(`"${formName}" field is empty<br/>`);
         }
         
         //straight append when it's not part of a nested element

--- a/BEIMA.Client/src/pages/Devices/AddDevicePage.js
+++ b/BEIMA.Client/src/pages/Devices/AddDevicePage.js
@@ -165,7 +165,7 @@ const AddDevicePage = () => {
   */
   async function saveDeviceToDb(addButtonEvent) {
     if (selectedDeviceType.name === 'Select Device Type'){
-      let isConfirmed = await Notifications.error("Device Type not selected", 'A device Type selection is required.');
+      Notifications.error("Device Type not selected", 'A device Type selection is required.');
       return;
     }
     

--- a/BEIMA.Client/src/pages/Devices/AddDevicePage.js
+++ b/BEIMA.Client/src/pages/Devices/AddDevicePage.js
@@ -163,9 +163,14 @@ const AddDevicePage = () => {
   * gathers data from the form and saves the device to the DB
   * @param the Add Device button click event
   */
-  function saveDeviceToDb(addButtonEvent) {
+  async function saveDeviceToDb(addButtonEvent) {
+    if (selectedDeviceType.name === 'Select Device Type'){
+      let isConfirmed = await Notifications.error("Device Type not selected", 'A device Type selection is required.');
+      return;
+    }
+    
     const formFields = addButtonEvent.target.form.elements;
-    const dbJson = createJSON(formFields);
+    const dbJson = await createJSON(formFields);
     if(dbJson){
       AddDevice(dbJson, deviceImage, deviceAdditionalDocs).then(response => {
         //reset the form or show a message regarding insertion failure
@@ -191,15 +196,11 @@ const AddDevicePage = () => {
   * @param the fields on the form from the button click event
   * @return the compiled JSON
   */
-  function createJSON(formFields){
-    if (selectedDeviceType.name === 'Select Device Type'){
-      Notifications.error("Device Type not selected", 'A device Type selection is required.');
-      return;
-    }
-    
+  async function createJSON(formFields){
     //sets up base db object/clears errors
     let dbJson = {fields: {}, location: { 'notes' : ""}};
     let newErrors = {};
+    let warnings = [];
     
     //loops through visible fields on the form
     for(let i = 0; i < formFields.length; i++){
@@ -228,6 +229,10 @@ const AddDevicePage = () => {
         let formJSON = '';
         let jsonKey = convertToDbFriendly(formName);
         
+        if(formFields[i].value.length === 0){
+          warnings.push(`${formName} field is empty<br/>`);
+        }
+        
         //straight append when it's not part of a nested element
         //otherwise it attaches it to the nested element
         if(!(typeof jsonKey == 'object')){
@@ -245,12 +250,17 @@ const AddDevicePage = () => {
     console.log(deviceImage);
     console.log(deviceAdditionalDocs);
     
+    let isConfirmed = true;
+    
     //display errors when present or attempt insert when valid data is present
     if ( Object.keys(newErrors).length > 0 ) {
       setErrors(newErrors);
       return false;
-    } else {
+    } else if (warnings.length > 0) {
+      isConfirmed = (await Notifications.warning('Warning', warnings)).isConfirmed;
+    }
     
+    if(isConfirmed) {
       dbJson.deviceTypeId = selectedDeviceType._id;
       dbJson.location.buildingId = selectedBuilding.id;
       

--- a/BEIMA.Client/src/pages/Devices/AddDevicePage.js
+++ b/BEIMA.Client/src/pages/Devices/AddDevicePage.js
@@ -61,7 +61,7 @@ const AddDevicePage = () => {
     const buildingList = await GetBuildingList();
     
     if(!(buildingList.status === Constants.HTTP_SUCCESS)){
-      Notifications.error("Unable to get building list for dropdown", `Contact support. Possible database connectivity issue.`);
+      Notifications.error("Unable to get building list for dropdown", `Contact support.`);
       return;
     }
     
@@ -78,7 +78,7 @@ const AddDevicePage = () => {
     const deviceTypeData = await GetDeviceTypeList();
     
     if(!(deviceTypeData.status === Constants.HTTP_SUCCESS)){
-      Notifications.error("Unable to get device type list for dropdown", `Contact support. Possible database connectivity issue.`);
+      Notifications.error("Unable to get device type list for dropdown", `Contact support.`);
       return;
     }
     
@@ -192,9 +192,8 @@ const AddDevicePage = () => {
   * @return the compiled JSON
   */
   function createJSON(formFields){
-    //TODO temporary until we have error signaling figured out
     if (selectedDeviceType.name === 'Select Device Type'){
-      alert ('No device type selected');
+      Notifications.error("Device Type not selected", 'A device Type selection is required.');
       return;
     }
     


### PR DESCRIPTION
<!--
These comments inside these brackets will not appear in the pull request.

The pull request should be linked to either:
 - a task (i.e., use 'Closes #TaskID' or 'Resolves #TaskID')
 - a bug (i.e., use 'Closes #BugID' or 'Fixes #BugID')

For more details, see: https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes #159

Moved confirmation that device type is selected to happen before trying to create JSON object
Added async to createJSON so the warning can be ignored
added check for isConfirmed from warning message to determine if save should still be attempted

![image](https://user-images.githubusercontent.com/46760776/161345111-70c161d2-6c97-43a6-9595-d084b7f76c95.png)

