### PR TITLE
Device type backend validation

### DIFF
--- a/BEIMA.Backend.Test/RulesTest.cs
+++ b/BEIMA.Backend.Test/RulesTest.cs
@@ -1,6 +1,7 @@
 ﻿using BEIMA.Backend.MongoService;
 using MongoDB.Bson;
 using NUnit.Framework;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
@@ -27,7 +28,7 @@ namespace BEIMA.Backend.Test
             // ARRANGE
             var device = new Device(ObjectId.GenerateNewId(), ObjectId.GenerateNewId(), "Tag", "Manufacturer", "Model", "SerialNumber", yearManufactured, "Notes");
             device.SetLocation(null, "Notes", "0.0", "0.0");
-            device.SetFields(new Dictionary<string, string> { { ObjectId.GenerateNewId().ToString(), "TestValue" } });
+            device.SetFields(new Dictionary<string, string> { { Guid.NewGuid().ToString().ToString(), "TestValue" } });
             var deviceType = new DeviceType(device.DeviceTypeId, "Name", "Description", "Notes.");
             deviceType.AddField(device.Fields.Keys.Single(), "TestField");
             var expectedResult = expectedStatusCode.Equals(HttpStatusCode.OK);
@@ -50,7 +51,7 @@ namespace BEIMA.Backend.Test
             // ARRANGE
             var device = new Device(ObjectId.GenerateNewId(), ObjectId.GenerateNewId(), "Tag", "Manufacturer", "Model", "SerialNumber", 2022, "Notes");
             device.SetLocation(null, "Notes", lat, lon);
-            device.SetFields(new Dictionary<string, string> { { ObjectId.GenerateNewId().ToString(), "TestValue" } });
+            device.SetFields(new Dictionary<string, string> { { Guid.NewGuid().ToString().ToString(), "TestValue" } });
             var deviceType = new DeviceType(device.DeviceTypeId, "Name", "Description", "Notes.");
             deviceType.AddField(device.Fields.Keys.Single(), "TestField");
 
@@ -74,7 +75,7 @@ namespace BEIMA.Backend.Test
             // ARRANGE
             var device = new Device(ObjectId.GenerateNewId(), ObjectId.GenerateNewId(), _longString, _longString, _longString, _longString, -1, _longString);
             device.SetLocation(null, _longString, "abc", "9999.0");
-            device.SetFields(new Dictionary<string, string> { { ObjectId.GenerateNewId().ToString(), _longString } });
+            device.SetFields(new Dictionary<string, string> { { Guid.NewGuid().ToString(), _longString } });
             var deviceType = new DeviceType(device.DeviceTypeId, "Name", "Description", "Notes.");
             deviceType.AddField(device.Fields.Keys.Single(), "TestField");
 
@@ -101,6 +102,109 @@ namespace BEIMA.Backend.Test
         }
 
         #endregion Device Rules
+
+        #region Device Type Rules
+
+        [Test]
+        public void DeviceTypeValid_IsDeviceTypeValid_ReturnsTrue()
+        {
+            var deviceType = new DeviceType(ObjectId.GenerateNewId(), "Name", "Description", "Notes.");
+            deviceType.AddField(Guid.NewGuid().ToString(), "TestField");
+
+            string message;
+            HttpStatusCode statusCode;
+
+            // ACT
+            var result = Rules.IsDeviceTypeValid(deviceType, out message, out statusCode);
+
+            // ASSERT
+            Assert.That(result, Is.True);
+            Assert.That(message, Is.EqualTo(string.Empty));
+            Assert.That(statusCode, Is.EqualTo(HttpStatusCode.OK));
+        }
+
+        [Test]
+        public void DeviceTypeMatchingFields_IsDeviceTypeValid_ReturnsFalse()
+        {
+            var deviceType = new DeviceType(ObjectId.GenerateNewId(), "Name", "Description", "Notes.");
+            deviceType.AddField(Guid.NewGuid().ToString(), "TestField");
+            deviceType.AddField(Guid.NewGuid().ToString(), "TestField");
+
+            string message;
+            HttpStatusCode statusCode;
+
+            // ACT
+            var result = Rules.IsDeviceTypeValid(deviceType, out message, out statusCode);
+
+            // ASSERT
+            Assert.That(result, Is.False);
+            Assert.That(message, Is.EqualTo("Cannot have matching field names."));
+            Assert.That(statusCode, Is.EqualTo(HttpStatusCode.BadRequest));
+        }
+
+        [Test]
+        public void DeviceTypeTooManyCharacterField_IsDeviceTypeValid_ReturnsFalse()
+        {
+            var deviceType = new DeviceType(ObjectId.GenerateNewId(), _longString, "Description", "Notes.");
+            deviceType.AddField(Guid.NewGuid().ToString(), "TestField");
+
+            string message;
+            HttpStatusCode statusCode;
+
+            // ACT
+            var result = Rules.IsDeviceTypeValid(deviceType, out message, out statusCode);
+
+            // ASSERT
+            Assert.That(result, Is.False);
+            Assert.That(message, Is.EqualTo("The max character length on field \"Name\" has been exceeded."));
+            Assert.That(statusCode, Is.EqualTo(HttpStatusCode.BadRequest));
+        }
+
+        [Test]
+        public void DeviceTypeTooManyCharacterCustomField_IsDeviceTypeValid_ReturnsFalse()
+        {
+            var deviceType = new DeviceType(ObjectId.GenerateNewId(), "Name", "Description", "Notes.");
+            deviceType.AddField(Guid.NewGuid().ToString(), _longString);
+
+            string message;
+            HttpStatusCode statusCode;
+
+            // ACT
+            var result = Rules.IsDeviceTypeValid(deviceType, out message, out statusCode);
+
+            // ASSERT
+            Assert.That(result, Is.False);
+            Assert.That(message, Is.EqualTo($"The max character length on field \"{_longString}\" has been exceeded."));
+            Assert.That(statusCode, Is.EqualTo(HttpStatusCode.BadRequest));
+        }
+
+        [Test]
+        public void DeviceTypeAllFieldsInvalid_IsDeviceTypeValid_ReturnsFalse()
+        {
+            var deviceType = new DeviceType(ObjectId.GenerateNewId(), _longString, _longString, _longString);
+            deviceType.AddField(Guid.NewGuid().ToString(), _longString);
+            deviceType.AddField(Guid.NewGuid().ToString(), _longString);
+
+            string message;
+            HttpStatusCode statusCode;
+
+            var expectedMessage = "Cannot have matching field names.\n" +
+                                  $"The max character length on field \"{_longString}\" has been exceeded.\n" +
+                                  $"The max character length on field \"{_longString}\" has been exceeded.\n" +
+                                  $"The max character length on field \"Name\" has been exceeded.\n" +
+                                  $"The max character length on field \"Description\" has been exceeded.\n" +
+                                  $"The max character length on field \"Notes\" has been exceeded.";
+
+            // ACT
+            var result = Rules.IsDeviceTypeValid(deviceType, out message, out statusCode);
+
+            // ASSERT
+            Assert.That(result, Is.False);
+            Assert.That(message, Is.EqualTo(expectedMessage));
+            Assert.That(statusCode, Is.EqualTo(HttpStatusCode.BadRequest));
+        }
+
+        #endregion Device Type Rules
 
         /// <summary>
         /// Generates a set of test case parameters relating to the device location.

--- a/BEIMA.Backend/Resources.Designer.cs
+++ b/BEIMA.Backend/Resources.Designer.cs
@@ -88,6 +88,15 @@ namespace BEIMA.Backend {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Cannot have matching field names..
+        /// </summary>
+        internal static string CannotHaveMatchingFieldNamesMessage {
+            get {
+                return ResourceManager.GetString("CannotHaveMatchingFieldNamesMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Could not parse the request body..
         /// </summary>
         internal static string CouldNotParseBody {

--- a/BEIMA.Backend/Resources.Designer.cs
+++ b/BEIMA.Backend/Resources.Designer.cs
@@ -133,6 +133,15 @@ namespace BEIMA.Backend {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Device type is null..
+        /// </summary>
+        internal static string DeviceTypeNullMessage {
+            get {
+                return ResourceManager.GetString("DeviceTypeNullMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Device year manufactured is invalid..
         /// </summary>
         internal static string DeviceYearManufacturedInvalidMessage {

--- a/BEIMA.Backend/Resources.resx
+++ b/BEIMA.Backend/Resources.resx
@@ -129,6 +129,10 @@
     <value>The device type could not be deleted because at least one device exists in the database with this device type.</value>
     <comment>Error message for trying to delete a device type that has at least one associated device in the database.</comment>
   </data>
+  <data name="CannotHaveMatchingFieldNamesMessage" xml:space="preserve">
+    <value>Cannot have matching field names.</value>
+    <comment>Error message for trying to create a device type with matching field names.</comment>
+  </data>
   <data name="CouldNotParseBody" xml:space="preserve">
     <value>Could not parse the request body.</value>
     <comment>Error message for when trying to parse a http request body fails.</comment>

--- a/BEIMA.Backend/Resources.resx
+++ b/BEIMA.Backend/Resources.resx
@@ -149,6 +149,10 @@
     <value>Device type could not be found.</value>
     <comment>Error message for when trying to access a device type that could not be found in the database.</comment>
   </data>
+  <data name="DeviceTypeNullMessage" xml:space="preserve">
+    <value>Device type is null.</value>
+    <comment>Error message for a null device type.</comment>
+  </data>
   <data name="DeviceYearManufacturedInvalidMessage" xml:space="preserve">
     <value>Device year manufactured is invalid.</value>
     <comment>Error message for an invalid device year manufactured.</comment>

--- a/BEIMA.Backend/Rules.cs
+++ b/BEIMA.Backend/Rules.cs
@@ -103,6 +103,14 @@ namespace BEIMA.Backend
             message = string.Empty;
             httpStatusCode = HttpStatusCode.OK;
 
+            // Check that device is not null
+            if (deviceType is null)
+            {
+                message = Resources.DeviceTypeNullMessage;
+                httpStatusCode = HttpStatusCode.BadRequest;
+                return false;
+            }
+
             // Check that fields don't have matching names
             var fields = deviceType.Fields.ToDictionary();
             if (fields.Values.Distinct().Count() != fields.Count)

--- a/BEIMA.Backend/Rules.cs
+++ b/BEIMA.Backend/Rules.cs
@@ -102,14 +102,41 @@ namespace BEIMA.Backend
             bool isValid = true;
             message = string.Empty;
             httpStatusCode = HttpStatusCode.OK;
-            // TODO: Check max string lengths?
+
+            // Check that fields don't have matching names
             var fields = deviceType.Fields.ToDictionary();
             if (fields.Values.Distinct().Count() != fields.Count)
             {
-                isValid = false;
-                message = "Cannot have matching field names";
+                message = Resources.CannotHaveMatchingFieldNamesMessage;
                 httpStatusCode = HttpStatusCode.BadRequest;
+                isValid = false;
             }
+
+            // Check custom field name lengths
+            foreach (var field in fields)
+            {
+                if (field.Value.ToString().Length > Constants.MAX_CHARACTER_LENGTH)
+                {
+                    message += message.Length > 0 ? '\n' : string.Empty;
+                    message += string.Format(Resources.MaxCharacterLengthExceededMessage, field.Value.ToString());
+                    httpStatusCode = HttpStatusCode.BadRequest;
+                    isValid = false;
+                }
+            }
+
+            // Check device type field name lengths
+            foreach (var prop in deviceType.GetType().GetProperties())
+            {
+                if (prop.PropertyType.Equals(typeof(string)) &&
+                    prop.GetValue(deviceType).ToString().Length > Constants.MAX_CHARACTER_LENGTH)
+                {
+                    message += message.Length > 0 ? '\n' : string.Empty;
+                    message += string.Format(Resources.MaxCharacterLengthExceededMessage, prop.Name);
+                    httpStatusCode = HttpStatusCode.BadRequest;
+                    isValid = false;
+                }
+            }
+
             return isValid;
         }
 


### PR DESCRIPTION
<!--
These comments inside these brackets will not appear in the pull request.

The pull request should be linked to either:
 - a task (i.e., use 'Closes #TaskID' or 'Resolves #TaskID')
 - a bug (i.e., use 'Closes #BugID' or 'Fixes #BugID')

For more details, see: https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes #294

This adds validation for device types to ensure that fields are formatted correctly.
