### PR TITLE
ReportWriter: Device Type Report

### DIFF
--- a/BEIMA.Backend.Test/ReportService/ReportServiceTest.cs
+++ b/BEIMA.Backend.Test/ReportService/ReportServiceTest.cs
@@ -83,7 +83,24 @@ namespace BEIMA.Backend.Test.ReportServices
             var bytes = ReportWriter.GenerateDeviceTypeReport(deviceTypeList, deviceList);
 
             // Assert
-            Assert.That(bytes, Is.Null);
+            Assert.That(bytes, Is.Not.Null);
+            var content = Encoding.UTF8.GetString(bytes);
+            var contentRows = content.Split(Environment.NewLine);
+            Assert.That(contentRows.Count, Is.EqualTo(2));
+
+            var headers = new List<List<string>>()
+            {
+                new List<string>() { "Id", "Name", "Description", "Notes" },
+                new List<string>() { "Date", "User" },
+                new List<string>() { "DeviceCount"}
+            };
+            var headerString = CombineColumnValues(headers);
+            Assert.That(contentRows[0], Is.EqualTo(headerString));
+
+            var rowOneDeviceList = new List<Device>();
+            var rowOne = DeviceTypeToColumnValues(deviceTypeOne, rowOneDeviceList);
+            var rowOneString = CombineColumnValues(rowOne);
+            Assert.That(contentRows[1], Is.EqualTo(rowOneString));
         }
 
 

--- a/BEIMA.Backend.Test/ReportService/ReportServiceTest.cs
+++ b/BEIMA.Backend.Test/ReportService/ReportServiceTest.cs
@@ -86,6 +86,21 @@ namespace BEIMA.Backend.Test.ReportServices
             Assert.That(bytes, Is.Null);
         }
 
+
+        [Test]
+        public void EmptyDeviceTypeListAndEmptyDeviceList_GenerateDeviceTypeReport_NullReturned()
+        {
+            // Arrange
+            var deviceTypeList = new List<DeviceType>(); ;
+            var deviceList = new List<Device>();
+
+            // ACT
+            var bytes = ReportWriter.GenerateDeviceTypeReport(deviceTypeList, deviceList);
+
+            // Assert
+            Assert.That(bytes, Is.Null);
+        }
+
         [Test]
         public void DeviceTypeAndNullDeviceList_GenerateReportByDeviceType_FileContainsOnlyHeader()
         {

--- a/BEIMA.Backend/Models/Reports.cs
+++ b/BEIMA.Backend/Models/Reports.cs
@@ -20,4 +20,18 @@ namespace BEIMA.Backend.Models
         public static List<PropertyInfo> LocationProps { get; } = typeof(MongoService.DeviceLocation).GetProperties().ToList(); // Uses mongoservice namespace as DeviceLocation exists in Requests.cs as a different model.
         public static List<PropertyInfo> LastModifiedProps { get; } = typeof(DeviceLastModified).GetProperties().ToList();
     }
+
+    /// <summary>
+    /// The DeviceTypeReportProps is a static class that represents all of the props associated with a devicetype except for the
+    /// Fields and LastModified props. It is used by the report writer to ensure that header and devicetype data values
+    /// are written in the same order. 
+    /// </summary>
+    public static class DeviceTypeReportProps
+    {
+        private static readonly string[] IgnoredPropNames = { "Fields", "LastModified" };
+        public static List<PropertyInfo> GeneralProps { get; } = typeof(DeviceType).GetProperties().Where(prop => !IgnoredPropNames.Contains(prop.Name)).ToList();
+        
+        // Must be hard coded as DeviceType uses BsonDocument instead of a c# object
+        public static Dictionary<string,string> LastModifiedProps { get; } = new Dictionary<string, string>(){ { "date", "Date"}, { "user", "User"} };
+    }
 }

--- a/BEIMA.Backend/ReportService/ReportWriter.cs
+++ b/BEIMA.Backend/ReportService/ReportWriter.cs
@@ -31,11 +31,6 @@ namespace BEIMA.Backend.ReportService
                 return null;
             }
 
-            if(devices == null || devices.Count == 0)
-            {
-                return null;
-            }
-
             // Create dict to group devices based on device type id
             var typeToDevices = new Dictionary<ObjectId, List<Device>>();
             foreach (var deviceType in deviceTypes)
@@ -43,15 +38,18 @@ namespace BEIMA.Backend.ReportService
                 typeToDevices.Add(deviceType.Id, new List<Device>());
             }
 
-            // Get all devices and add them to the dict based on deviceTypeId            
-            foreach (var device in devices)
+            // Get all devices and add them to the dict based on deviceTypeId
+            if(devices != null)
             {
-                // Only add a device if it's deviceType exists in the deviceTypes list. Should always be the case
-                if (typeToDevices.ContainsKey(device.DeviceTypeId))
+                foreach (var device in devices)
                 {
-                    typeToDevices[device.DeviceTypeId].Add(device);
+                    // Only add a device if it's deviceType exists in the deviceTypes list. Should always be the case
+                    if (typeToDevices.ContainsKey(device.DeviceTypeId))
+                    {
+                        typeToDevices[device.DeviceTypeId].Add(device);
+                    }
                 }
-            }
+            }            
 
             byte[] fileBytes;
             using (var stream = new MemoryStream())


### PR DESCRIPTION
<!--
These comments inside these brackets will not appear in the pull request.

The pull request should be linked to either:
 - a task (i.e., use 'Closes #TaskID' or 'Resolves #TaskID')
 - a bug (i.e., use 'Closes #BugID' or 'Fixes #BugID')

For more details, see: https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes #389

Adds a method to the report writer to allow it to generate a file containing a list of
all device types in the database as well as a count of how many devices are associated
with each device type.
