### PR TITLE
Enforce unique usernames on AddUser and UpdateUser

### DIFF
--- a/BEIMA.Backend.Test/TestData.cs
+++ b/BEIMA.Backend.Test/TestData.cs
@@ -108,6 +108,15 @@ namespace BEIMA.Backend.Test
                 "\"role\": \"user\"" +
             "}";
 
+        public const string _testUserDuplicateUsername =
+            "{" +
+                "\"username\": \"---\"," +
+                "\"password\": \"ThisIsAPassword1!\"," +
+                "\"firstName\": \"Alex\"," +
+                "\"lastName\": \"Smith\"," +
+                "\"role\": \"user\"" +
+            "}";
+
         public const string _testUserBadPassword =
             "{" +
                 "\"username\": \"user.name\"," +

--- a/BEIMA.Backend.Test/UserFunctions/AddUserTest.cs
+++ b/BEIMA.Backend.Test/UserFunctions/AddUserTest.cs
@@ -25,6 +25,9 @@ namespace BEIMA.Backend.Test.UserFunctions
             mockDb.Setup(mock => mock.InsertUser(It.IsAny<BsonDocument>()))
                   .Returns(ObjectId.GenerateNewId())
                   .Verifiable();
+            mockDb.Setup(mock => mock.GetFilteredUsers(It.Is<FilterDefinition<BsonDocument>>(filter => filter != null)))
+                  .Returns(new List<BsonDocument>())
+                  .Verifiable();
             MongoDefinition.MongoInstance = mockDb.Object;
 
             // Create request

--- a/BEIMA.Backend.Test/UserFunctions/AddUserTest.cs
+++ b/BEIMA.Backend.Test/UserFunctions/AddUserTest.cs
@@ -76,7 +76,7 @@ namespace BEIMA.Backend.Test.UserFunctions
                         Is.EqualTo("Password is invalid. Password must be at least 8 characters and contain at least an uppercase letter, a number, and a special character."));
         }
 
-        //[TestCase("user.name")]
+        [TestCase("user.name")]
         [TestCase("testUser")]
         [TestCase("12345")]
         [TestCase("true")]
@@ -86,14 +86,14 @@ namespace BEIMA.Backend.Test.UserFunctions
             // ARRANGE
             // Setup mock database client
 
-            var user1 = new User(ObjectId.GenerateNewId(), username, "ThisIsAPassword1!", "Alex", "Smith", "user");
+            var user = new User(ObjectId.GenerateNewId(), username, "ThisIsAPassword1!", "Alex", "Smith", "user");
 
             Mock<IMongoConnector> mockDb = new Mock<IMongoConnector>();
             mockDb.Setup(mock => mock.InsertUser(It.IsAny<BsonDocument>()))
                   .Returns(ObjectId.GenerateNewId())
                   .Verifiable();
             mockDb.Setup(mock => mock.GetFilteredUsers(It.Is<FilterDefinition<BsonDocument>>(filter => filter != null)))
-                  .Returns(new List<BsonDocument> { user1.ToBsonDocument() })
+                  .Returns(new List<BsonDocument> { user.ToBsonDocument() })
                   .Verifiable();
             MongoDefinition.MongoInstance = mockDb.Object;
 

--- a/BEIMA.Backend/Resources.Designer.cs
+++ b/BEIMA.Backend/Resources.Designer.cs
@@ -223,6 +223,15 @@ namespace BEIMA.Backend {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Username already exists..
+        /// </summary>
+        internal static string UsernameAlreadyExistsMessage {
+            get {
+                return ResourceManager.GetString("UsernameAlreadyExistsMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to User could not be found..
         /// </summary>
         internal static string UserNotFoundMessage {

--- a/BEIMA.Backend/Resources.resx
+++ b/BEIMA.Backend/Resources.resx
@@ -197,4 +197,8 @@
     <value>User is null.</value>
     <comment>Error message for a null user.</comment>
   </data>
+  <data name="UsernameAlreadyExistsMessage" xml:space="preserve">
+    <value>Username already exists.</value>
+    <comment>Error message for when a username has already been taken. Another username must be chosen.</comment>
+  </data>
 </root>

--- a/BEIMA.Backend/UserFunctions/UpdateUser.cs
+++ b/BEIMA.Backend/UserFunctions/UpdateUser.cs
@@ -60,11 +60,21 @@ namespace BEIMA.Backend.UserFunctions
                 {
                     return new NotFoundObjectResult(Resources.UserNotFoundMessage);
                 }
+                var originalUserRecord = BsonSerializer.Deserialize<User>(originalUserDoc);
+
+                // Check for username uniqueness
+                if (originalUserRecord.Username != updatedUserRecord.Username)
+                {
+                    var filter = MongoFilterGenerator.GetEqualsFilter("username", updatedUserRecord.Username);
+                    if (mongo.GetFilteredUsers(filter).Count > 0)
+                    {
+                        return new ConflictObjectResult(Resources.UsernameAlreadyExistsMessage);
+                    }
+                }
 
                 // If the password sent in is null or empty string, then do not update the password.
                 if (string.IsNullOrEmpty(updatedUserRecord.Password))
                 {
-                    var originalUserRecord = BsonSerializer.Deserialize<User>(originalUserDoc);
                     updatedUserRecord.Password = originalUserRecord.Password;
                 }
                 else


### PR DESCRIPTION
<!--
These comments inside these brackets will not appear in the pull request.

The pull request should be linked to either:
 - a task (i.e., use 'Closes #TaskID' or 'Resolves #TaskID')
 - a bug (i.e., use 'Closes #BugID' or 'Fixes #BugID')

For more details, see: https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes #384 
Closes #401 

This PR implements the constraint of forcing usernames to be unique. On the AddUser endpoint, a 409 Conflict error is returned when a user tries to insert a new user with a username that is already being used. On the UpdateUser endpoint, a 409 Conflict error is returned when a user tries to update their username to a username that already exists.
