### PR TITLE
Add device list endpoint filters

### DIFF
--- a/BEIMA.Backend.FT/BeimaClient.cs
+++ b/BEIMA.Backend.FT/BeimaClient.cs
@@ -190,10 +190,11 @@ namespace BEIMA.Backend.FT
         /// <summary>
         /// Sends a device get list request to the BEIMA api.
         /// </summary>
+        /// <param name="query">The query string to filter devices with.</param>
         /// <returns>The device list.</returns>
-        public async Task<List<Device>> GetDeviceList()
+        public async Task<List<Device>> GetDeviceList(string query = "")
         {
-            var response = await SendRequest("api/device-list", HttpVerb.GET);
+            var response = await SendRequest("api/device-list", HttpVerb.GET, queryString: query);
             var content = await response.Content.ReadAsStringAsync();
             return JsonConvert.DeserializeObject<List<Device>>(content);
         }
@@ -422,7 +423,7 @@ namespace BEIMA.Backend.FT
         #endregion
 
         #region Auth Requests
-        
+
         /// <summary>
         /// Sends a login post request to the BEIMA api.
         /// </summary>

--- a/BEIMA.Backend/DeviceFunctions/GetDeviceList.cs
+++ b/BEIMA.Backend/DeviceFunctions/GetDeviceList.cs
@@ -6,7 +6,9 @@ using Microsoft.Azure.WebJobs.Extensions.Http;
 using Microsoft.Extensions.Logging;
 using MongoDB.Bson;
 using MongoDB.Bson.Serialization;
+using MongoDB.Driver;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace BEIMA.Backend.DeviceFunctions
 {
@@ -29,7 +31,80 @@ namespace BEIMA.Backend.DeviceFunctions
             log.LogInformation("C# HTTP trigger function processed a device list request.");
 
             var mongo = MongoDefinition.MongoInstance;
-            var devices = mongo.GetAllDevices();
+            var filter = Builders<BsonDocument>.Filter.Empty;
+
+            // If query filter parameters are defined then apply filters
+            if (req.Query is not null && req.Query.Count > 0)
+            {
+                // Parse all device type filters
+                var deviceTypeFilters = new List<FilterDefinition<BsonDocument>>();
+                if (req.Query.ContainsKey("deviceType"))
+                {
+                    foreach (var queryId in req.Query["deviceType"].ToArray())
+                    {
+                        ObjectId id;
+                        if (ObjectId.TryParse(queryId, out id))
+                        {
+                            deviceTypeFilters.Add(MongoFilterGenerator.GetEqualsFilter("deviceTypeId", id));
+                        }
+                    }
+                }
+
+                // Parse all building filters
+                var buildingFilters = new List<FilterDefinition<BsonDocument>>();
+                if (req.Query.ContainsKey("building"))
+                {
+                    foreach (var queryId in req.Query["building"].ToArray())
+                    {
+                        ObjectId id;
+                        if (ObjectId.TryParse(queryId, out id))
+                        {
+                            buildingFilters.Add(MongoFilterGenerator.GetEqualsFilter("location.buildingId", id));
+                        }
+                    }
+                }
+
+                FilterDefinition<BsonDocument> deviceTypeFilter = null;
+                FilterDefinition<BsonDocument> buildingFilter = null;
+
+                // Create device type filter
+                if (deviceTypeFilters.Count == 1)
+                {
+                    deviceTypeFilter = deviceTypeFilters.Single();
+                }
+                else if (deviceTypeFilters.Count > 1)
+                {
+                    deviceTypeFilter = MongoFilterGenerator.OrFilters(deviceTypeFilters.ToArray());
+                }
+
+                // Create building filter
+                if (buildingFilters.Count == 1)
+                {
+                    buildingFilter = buildingFilters.Single();
+                }
+                else if (buildingFilters.Count > 1)
+                {
+                    buildingFilter = MongoFilterGenerator.OrFilters(buildingFilters.ToArray());
+                }
+
+                // Create the final filter, or leave as empty filter if there are no device type/building filters
+                if (deviceTypeFilter != null && buildingFilter != null)
+                {
+                    filter = MongoFilterGenerator.AndFilters(deviceTypeFilter, buildingFilter);
+                }
+                else if (deviceTypeFilter != null)
+                {
+                    filter = deviceTypeFilter;
+                }
+                else if (buildingFilter != null)
+                {
+                    filter = buildingFilter;
+                }
+
+            }
+
+            var devices = mongo.GetFilteredDevices(filter);
+
             var dotNetObjList = new List<Device>();
             foreach (var device in devices)
             {


### PR DESCRIPTION
<!--
These comments inside these brackets will not appear in the pull request.

The pull request should be linked to either:
 - a task (i.e., use 'Closes #TaskID' or 'Resolves #TaskID')
 - a bug (i.e., use 'Closes #BugID' or 'Fixes #BugID')

For more details, see: https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes #409

This adds the capability for us to use deviceType and building filters using the query string on the device list endpoint.
Example query string:
  - localhost:7071/api/device-list?deviceType=aaaa&building=bbbb&building=cccc
  This query would return the list of device with ```deviceTypeId 'aaaa' AND (buildingId 'bbbb' OR buildingId 'cccc')```
