### PR TITLE
#217 Indicate More Tile Data

### DIFF
--- a/BEIMA.Client/src/pages/DeviceTypes/DeviceTypePage.js
+++ b/BEIMA.Client/src/pages/DeviceTypes/DeviceTypePage.js
@@ -1,10 +1,11 @@
-import { useState, useEffect } from "react"
+import { useState, useEffect, useRef } from "react"
 import {ItemCard} from "../../shared/ItemCard/ItemCard"
 import * as Notifications from '../../shared/Notifications/Notification.js'
 import styles from './DeviceTypePage.module.css'
 import { useOutletContext, useParams, useNavigate } from 'react-router-dom';
 import { Form, Card, Button, FormControl} from "react-bootstrap";
 import { IoAdd } from "react-icons/io5";
+import { IoChevronBack, IoChevronForward } from "react-icons/io5";
 import { v4 as uuidv4 } from 'uuid';
 import GetDeviceType from '../../services/GetDeviceType';
 import updateDeviceType from '../../services/UpdateDeviceType';
@@ -43,11 +44,27 @@ const DeviceTypePage = () => {
    * @returns 
    */
   const Field = ({field, value, editable, fieldChange, deleteField}) => {
+    const [expanded, setExpanded] = useState(false);
+    const textareaRef = useRef(null);
+
+    useEffect(() => {
+      if(textareaRef != null && textareaRef.current != null){
+        textareaRef.current.style.height = "0px";
+        const scrollHeight = textareaRef.current.scrollHeight;
+        textareaRef.current.style.height = scrollHeight + "px";
+      }
+    }, [value, expanded]);
+
     return (
-      <Card>
+      <Card className={expanded ? styles.expandedCard : ''}>
         <Card.Body >
-            <Form.Group className="mb-3" controlId={field}>
-              <FormControl required type="text" disabled={!editable} size="sm" placeholder="Field Name" value={value} onChange={fieldChange}  maxLength={Constants.MAX_INPUT_CHARACTER_LENGTH}/>
+            <Form.Group className={[styles.row, "mb-3"].join(' ')} controlId={field}>
+              {expanded ? 
+                <FormControl required ref={textareaRef} className={styles.expandedInput}  as="textarea" disabled={!editable} size="sm" placeholder="Field Name" value={value} onChange={fieldChange}  maxLength={Constants.MAX_INPUT_CHARACTER_LENGTH}/> 
+                :
+                <FormControl required ref={textareaRef} className={styles.unexpandedInput}  type="text" disabled={!editable} size="sm" placeholder="Field Name" value={value} onChange={fieldChange}  maxLength={Constants.MAX_INPUT_CHARACTER_LENGTH}/> 
+              }
+              <div>{expanded ? <IoChevronBack className={styles.hover} size={15} onClick={() => setExpanded(false)}/> : <IoChevronForward className={styles.hover} size={15} onClick={() => setExpanded(true)}/>}</div>
             </Form.Group>                
           { editable ? 
            <div className={styles.deleteButton}>

--- a/BEIMA.Client/src/pages/DeviceTypes/DeviceTypePage.module.css
+++ b/BEIMA.Client/src/pages/DeviceTypes/DeviceTypePage.module.css
@@ -6,8 +6,22 @@
   display:flex;
   flex-direction: row;
   justify-content: center;
-  align-items: flex-end;
+  align-items: flex-start;
   gap:10px;
+}
+
+.expandedCard{
+  width:100%;
+}
+
+.expandedInput{
+  overflow: hidden;
+}
+
+.unexpandedInput{
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden; 
 }
 
 .editRow {

--- a/BEIMA.Client/src/pages/Devices/DevicePage.js
+++ b/BEIMA.Client/src/pages/Devices/DevicePage.js
@@ -10,6 +10,7 @@ import deleteDevice from "../../services/DeleteDevice.js";
 import getDevice from "../../services/GetDevice.js";
 import GetDeviceType from '../../services/GetDeviceType';
 import GetBuilding from '../../services/GetBuilding.js';
+import { IoChevronBack, IoChevronForward } from "react-icons/io5";
 import * as Constants from '../../Constants';
 
 const DevicePage = () => {
@@ -60,12 +61,47 @@ const DevicePage = () => {
    * @returns 
    */
   const FormCard = ({editable, id, label, value, onChange }) => {
+    const [expanded, setExpanded] = useState(false);
+    const textareaRef = useRef(null);
+
+    useEffect(() => {
+      if(textareaRef != null && textareaRef.current != null){
+        textareaRef.current.style.height = "0px";
+        const scrollHeight = textareaRef.current.scrollHeight;
+        textareaRef.current.style.height = scrollHeight + "px";
+      }
+    }, [value, expanded]);
+
     return (
-      <Card>
+      <Card className={expanded ? styles.expandedCard : ''}>
         <Card.Body >
           <Form.Group className="mb-3" controlId={id}>
-            <Form.Label>{label}</Form.Label>
-            <FormControl required type="text" disabled={!editable} size="sm" value={value} onChange={onChange} maxLength={Constants.MAX_INPUT_CHARACTER_LENGTH}/>
+            <div className={styles.row}>
+              <Form.Label>{label}</Form.Label>
+              <div>{expanded ? <IoChevronBack className={styles.hover} size={15} onClick={() => setExpanded(false)}/> : <IoChevronForward className={styles.hover} size={15} onClick={() => setExpanded(true)}/>}</div>
+            </div>
+            {expanded ? 
+              <FormControl 
+                required
+                ref={textareaRef}
+                as="textarea"
+                className={styles.expandedInput} 
+                disabled={!editable} size="sm" 
+                value={value ?? ""} 
+                onChange={onChange} 
+                maxLength={Constants.MAX_INPUT_CHARACTER_LENGTH}
+              />
+              :
+              <FormControl 
+                required 
+                type="text"
+                className={styles.unexpandedInput} 
+                disabled={!editable} size="sm" 
+                value={value ?? ""} 
+                onChange={onChange} 
+                maxLength={Constants.MAX_INPUT_CHARACTER_LENGTH}
+              />
+            }            
           </Form.Group>                
         </Card.Body>
       </Card>

--- a/BEIMA.Client/src/pages/Devices/DevicePage.module.css
+++ b/BEIMA.Client/src/pages/Devices/DevicePage.module.css
@@ -13,6 +13,28 @@
   gap:10px;
 }
 
+.row {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: flex-start;
+  margin-bottom: 5px;
+}
+
+.expandedCard{
+  width:100%;
+}
+
+.expandedInput{
+  overflow: hidden;
+}
+
+.unexpandedInput{
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden; 
+}
+
 .deleteButton {
   float: right;
 }
@@ -23,6 +45,13 @@
   justify-content: flex-start;
   flex-wrap: wrap;
   gap:10px;
+}
+
+.hover:hover  {
+  background: #ebedf7;
+  box-shadow: 0 0 0px 5px #ebedf7;
+  cursor:pointer;
+  user-select: none;
 }
 
 .image {

--- a/BEIMA.Client/src/shared/ItemCard/ItemCard.js
+++ b/BEIMA.Client/src/shared/ItemCard/ItemCard.js
@@ -32,7 +32,7 @@ const LoadingContent = () => {
  */
 export const ItemCard = ({title, RenderItem, loading, route}) => {
   return (
-    <Card id="itemCard">
+    <Card id="itemCard" className={styles.itemCard}>
       <Card.Body>
         <Card.Title className={styles.cardtitle}>
           <Link to={route} className={styles.back}>

--- a/BEIMA.Client/src/shared/ItemCard/ItemCard.module.css
+++ b/BEIMA.Client/src/shared/ItemCard/ItemCard.module.css
@@ -18,3 +18,7 @@
   gap:10px;
   flex-direction: row;
 }
+
+.itemCard {
+  margin-bottom: 25px;
+}

--- a/BEIMA.Client/src/shared/ItemList/ItemList.js
+++ b/BEIMA.Client/src/shared/ItemList/ItemList.js
@@ -49,7 +49,7 @@ const Item = ({item, RenderItem, isDeviceList}) => {
     <div className={styles.item}>
       <div className={styles.row}> 
         {isDeviceList ? <div className={styles.itemName}>{item.deviceTag} - {item.deviceTypeName} - {item.buildingName}</div> : <div className={styles.itemName}>{item.name}</div>}
-        <MdMoreHoriz color='#f44336' className={styles.hover} size={30} onClick={() => navigate(`${item.id}`)}/>
+        <div><MdMoreHoriz color='#f44336' className={styles.hover} size={30} onClick={() => navigate(`${item.id}`)}/></div>
       </div>
 
       <div className={styles.itemContent}>

--- a/BEIMA.Client/src/shared/ItemList/ItemList.module.css
+++ b/BEIMA.Client/src/shared/ItemList/ItemList.module.css
@@ -21,7 +21,6 @@
   display: flex;
   flex-direction: row;
   justify-content: space-between;
-  align-items: center;
   margin-bottom: 5px;
 }
 


### PR DESCRIPTION
<!--
These comments inside these brackets will not appear in the pull request.

The pull request should be linked to either:
 - a task (i.e., use 'Closes #TaskID' or 'Resolves #TaskID')
 - a bug (i.e., use 'Closes #BugID' or 'Fixes #BugID')

For more details, see: https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes #217 

Add ability to expand field tile in order to see all of the text on the device and device type pages. When not expanded the input will show "fieldtext..." Additionally fix some css issues on the device and device type list view that would hide the details button when title of an item was very long.

![image](https://user-images.githubusercontent.com/47906870/162659514-b3d6f45a-a1c9-40ea-bf45-7059bc23bd5d.png)
![image](https://user-images.githubusercontent.com/47906870/162659539-bea78f81-7a0c-40b6-bc0e-81c0f06a01fc.png)
![image](https://user-images.githubusercontent.com/47906870/162659569-a2eafb54-5f04-4807-ab20-c52f3b057e65.png)
![image](https://user-images.githubusercontent.com/47906870/162659830-a3348887-2a0a-47e9-ac0d-6629ca9418ef.png)

