### PR TITLE
Device Type page - Added warning for blank editable fields

### DIFF
--- a/BEIMA.Client/src/pages/DeviceTypes/DeviceTypePage.js
+++ b/BEIMA.Client/src/pages/DeviceTypes/DeviceTypePage.js
@@ -100,6 +100,8 @@ const DeviceTypePage = () => {
       // we keep track of the added fields as an object, but the endpoint takes in an array
       // so we grab the values from the addFields object and send it to the endpoint
       let newFields = Object.values(addedFields);
+      let warnings = [];
+      let isConfirmed = true;
 
       const result = {
         id: typeId,
@@ -110,13 +112,27 @@ const DeviceTypePage = () => {
         newFields: newFields,
         deletedFields: deletedFields
       }
-      //call endpoint
-      let updateResult = await updateDeviceType(result);
-      if(updateResult.status === Constants.HTTP_SUCCESS){
-        Notifications.success("Update Device Type Successful", `Device Type ${item.name} updated successfully.`)
-        setEditable(false)
-      } else {
-        Notifications.error("Unable to Update Device Type", `Update of Device Type ${item.name} failed.`);
+      
+      Object.entries(result).forEach(entry => {
+        const [key, value] = entry;
+        if(value === ""){
+          warnings.push(`"${key}" field is empty<br/>`);
+        }
+      });
+      
+      if( warnings.length > 0 ){
+        isConfirmed = (await Notifications.multiWarning('Warning', warnings)).isConfirmed;
+      }
+      
+      if ( isConfirmed ) {
+        //call endpoint
+        let updateResult = await updateDeviceType(result);
+        if(updateResult.status === Constants.HTTP_SUCCESS){
+          Notifications.success("Update Device Type Successful", `Device Type ${item.name} updated successfully.`)
+          setEditable(false)
+        } else {
+          Notifications.error("Unable to Update Device Type", `Update of Device Type ${item.name} failed.`);
+        }
       }
     }
 


### PR DESCRIPTION
<!--
These comments inside these brackets will not appear in the pull request.

The pull request should be linked to either:
 - a task (i.e., use 'Closes #TaskID' or 'Resolves #TaskID')
 - a bug (i.e., use 'Closes #BugID' or 'Fixes #BugID')

For more details, see: https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes #162 
warns on empty notes and description, allows without prompt when both present, warns when either one are missing
![deviceType - no desc](https://user-images.githubusercontent.com/46760776/163292463-d4df40bb-e607-4e71-ac7f-c1e6f7ab0e26.jpg)

![deviceType - no notes](https://user-images.githubusercontent.com/46760776/163292472-1dde5e9c-d1ca-40e0-ae34-b3fd318f3326.jpg)
![deviceType - no desc no notes](https://user-images.githubusercontent.com/46760776/163292485-6b05b926-473d-404b-b21d-52c84ad35b85.jpg)
![deviceType - a-ok](https://user-images.githubusercontent.com/46760776/163292490-5a9512bc-50b8-41d0-b467-16e626d20b8c.jpg)

