### PR TITLE
Case insensitivity for usernames

### DIFF
--- a/BEIMA.Backend.FT/UserFT.cs
+++ b/BEIMA.Backend.FT/UserFT.cs
@@ -388,5 +388,40 @@ namespace BEIMA.Backend.FT
             Assert.That(ex, Is.Not.Null);
             Assert.That(ex?.StatusCode, Is.EqualTo(HttpStatusCode.Conflict));
         }
+
+        [Test]
+        public async Task UserInDatabase_AddUserWithSameUsernameDifferentCapitalization_ConflictObjectResultReturned()
+        {
+            // ARRANGE
+            var existingUser = new User
+            {
+                Username = "user.name",
+                Password = "Abcdefg12345!",
+                FirstName = "Alex",
+                LastName = "Smith",
+                Role = "user"
+            };
+            var existingUserId = await TestClient.AddUser(existingUser);
+            Assume.That(existingUserId, Is.Not.Null);
+            Assume.That(existingUserId, Is.Not.EqualTo(string.Empty));
+            Assume.That(ObjectId.TryParse(existingUserId, out _), Is.True);
+
+            // ACT
+            var newUser = new User
+            {
+                Username = "User.Name",
+                Password = "Abcdefg12345!",
+                FirstName = "Alex2",
+                LastName = "SmithDuplicate",
+                Role = "user"
+            };
+            var ex = Assert.ThrowsAsync<BeimaException>(async () =>
+                await TestClient.AddUser(newUser)
+            );
+
+            // ASSERT
+            Assert.That(ex, Is.Not.Null);
+            Assert.That(ex?.StatusCode, Is.EqualTo(HttpStatusCode.Conflict));
+        }
     }
 }

--- a/BEIMA.Backend.FT/UserFT.cs
+++ b/BEIMA.Backend.FT/UserFT.cs
@@ -101,6 +101,39 @@ namespace BEIMA.Backend.FT
         }
 
         [Test]
+        public async Task UserNotInDatabase_AddUserWithUsernameCapitalization_CreatesNewUserWithLowerCaseUsername()
+        {
+            // ARRANGE
+            var user = new User
+            {
+                Username = "useR.NaMe",
+                Password = "Abcdefg12345!",
+                FirstName = "Alex",
+                LastName = "Smith",
+                Role = "user"
+            };
+
+            // ACT
+            var responseId = await TestClient.AddUser(user);
+
+            // ASSERT
+            Assert.That(responseId, Is.Not.Null);
+            Assert.That(ObjectId.TryParse(responseId, out _), Is.True);
+
+            var getUser = await TestClient.GetUser(responseId);
+            Assert.That(getUser.Username?.ToLower(), Is.EqualTo(user.Username.ToLower()));
+            // GET endpoints should not expose password, will always return empty string
+            Assert.That(getUser.Password, Is.EqualTo(string.Empty));
+            Assert.That(getUser.FirstName, Is.EqualTo(user.FirstName));
+            Assert.That(getUser.LastName, Is.EqualTo(user.LastName));
+            Assert.That(getUser.Role, Is.EqualTo(user.Role));
+
+            Assert.That(getUser.LastModified, Is.Not.Null);
+            Assert.That(getUser.LastModified?.Date, Is.Not.Null);
+            Assert.That(getUser.LastModified?.User, Is.EqualTo("Anonymous"));
+        }
+
+        [Test]
         public async Task UsersInDatabase_GetUserList_ReturnsUserList()
         {
             // ARRANGE
@@ -417,6 +450,56 @@ namespace BEIMA.Backend.FT
             };
             var ex = Assert.ThrowsAsync<BeimaException>(async () =>
                 await TestClient.AddUser(newUser)
+            );
+
+            // ASSERT
+            Assert.That(ex, Is.Not.Null);
+            Assert.That(ex?.StatusCode, Is.EqualTo(HttpStatusCode.Conflict));
+        }
+
+        [Test]
+        public async Task TwoUsersInDatabase_UpdateUserWithDuplicateUsernameWithCapitalization_ConflictObjectResultReturned()
+        {
+            // ARRANGE
+            var existingUser = new User
+            {
+                Username = "user.name",
+                Password = "Abcdefg12345!",
+                FirstName = "Alex",
+                LastName = "Smith",
+                Role = "user"
+            };
+            var existingUserId = await TestClient.AddUser(existingUser);
+            Assume.That(existingUserId, Is.Not.Null);
+            Assume.That(existingUserId, Is.Not.EqualTo(string.Empty));
+
+            var updateUser = new User
+            {
+                Username = "someOtherUsername",
+                Password = "Abcdefg12345!",
+                FirstName = "Alex",
+                LastName = "Smith",
+                Role = "user"
+            };
+
+            var userId = await TestClient.AddUser(updateUser);
+            var origItem = await TestClient.GetUser(userId);
+
+            Assume.That(origItem, Is.Not.Null);
+
+            var updateItem = new User
+            {
+                Id = userId,
+                Username = "user.NAME",
+                Password = "",
+                FirstName = "Alexis",
+                LastName = "Smith",
+                Role = "user"
+            };
+
+            // ACT
+            var ex = Assert.ThrowsAsync<BeimaException>(async () =>
+                await TestClient.UpdateUser(updateItem)
             );
 
             // ASSERT

--- a/BEIMA.Backend.Test/AuthFunctions/LoginTest.cs
+++ b/BEIMA.Backend.Test/AuthFunctions/LoginTest.cs
@@ -173,5 +173,60 @@ namespace BEIMA.Backend.Test.AuthFunctions
             Assert.That(claims.Iss, Is.EqualTo("Beima"));
         }
 
+        [Test]
+        public async Task ValidParametersMatchingUserWithCapitalizedUsername_Login_ReturnsToken()
+        {
+            var hashed = BCryptNet.HashPassword("Pass");
+            User user = new User()
+            {
+                Id = ObjectId.GenerateNewId(),
+                Username = "useR",
+                Password = hashed,
+                Role = "Admin",
+                FirstName = "First",
+                LastName = "Last",
+                LastModified = new UserLastModified()
+                {
+                    Date = DateTime.Now,
+                    User = "anon"
+                }
+            };
+
+            var filteredUsers = new List<BsonDocument>()
+            {
+                user.ToBsonDocument()
+            };
+
+            // ARRANGE
+            Mock<IMongoConnector> mockDb = new Mock<IMongoConnector>();
+            mockDb.Setup(mock => mock.GetFilteredUsers(It.IsAny<FilterDefinition<BsonDocument>>()))
+                  .Returns(filteredUsers)
+                  .Verifiable();
+            MongoDefinition.MongoInstance = mockDb.Object;
+
+            var body = TestData._testValidKeysLoginRequest;
+            var request = CreateHttpRequest(RequestMethod.POST, body: body);
+            var logger = (new LoggerFactory()).CreateLogger("Testing");
+
+            // ACT
+            var token = ((ObjectResult)await Login.Run(request, logger)).Value?.ToString();
+
+            // ASSERT
+            Assert.IsNotNull(token);
+            Assert.DoesNotThrow(() => mockDb.Verify(mock => mock.GetFilteredUsers(It.IsAny<FilterDefinition<BsonDocument>>()), Times.Once));
+            var claims = new JwtBuilder().Decode<Claims>(token);
+            Assert.That(claims.Username.ToLower(), Is.EqualTo(user.Username.ToLower()));
+            Assert.That(claims.Role, Is.EqualTo(user.Role));
+
+            // Expiration of token is 7 days after creation. Should be 6 days 23 hours 59min xx seconds greater then datetime now
+            var nowPlus6 = DateTime.Now.AddDays(6).AddHours(23).AddMinutes(59).Ticks;
+            var nowPlus7 = DateTime.Now.AddDays(7).Ticks;
+
+            Assert.That(claims.Exp, Is.GreaterThan(nowPlus6));
+            Assert.That(claims.Exp, Is.LessThan(nowPlus7));
+            Assert.That(claims.Sub, Is.EqualTo("User"));
+            Assert.That(claims.Iss, Is.EqualTo("Beima"));
+        }
+
     }
 }

--- a/BEIMA.Backend.Test/AuthFunctions/LoginTest.cs
+++ b/BEIMA.Backend.Test/AuthFunctions/LoginTest.cs
@@ -180,7 +180,7 @@ namespace BEIMA.Backend.Test.AuthFunctions
             User user = new User()
             {
                 Id = ObjectId.GenerateNewId(),
-                Username = "useR",
+                Username = "user",
                 Password = hashed,
                 Role = "Admin",
                 FirstName = "First",
@@ -215,7 +215,7 @@ namespace BEIMA.Backend.Test.AuthFunctions
             Assert.IsNotNull(token);
             Assert.DoesNotThrow(() => mockDb.Verify(mock => mock.GetFilteredUsers(It.IsAny<FilterDefinition<BsonDocument>>()), Times.Once));
             var claims = new JwtBuilder().Decode<Claims>(token);
-            Assert.That(claims.Username.ToLower(), Is.EqualTo(user.Username.ToLower()));
+            Assert.That(claims.Username, Is.EqualTo(user.Username.ToLower()));
             Assert.That(claims.Role, Is.EqualTo(user.Role));
 
             // Expiration of token is 7 days after creation. Should be 6 days 23 hours 59min xx seconds greater then datetime now

--- a/BEIMA.Backend/AuthFunctions/Login.cs
+++ b/BEIMA.Backend/AuthFunctions/Login.cs
@@ -50,7 +50,7 @@ namespace BEIMA.Backend.AuthFunctions
 
                 // Get all users with request's username
                 var dbServce = MongoDefinition.MongoInstance;
-                var usernameFilter = MongoFilterGenerator.GetEqualsFilter("username", data.Username);
+                var usernameFilter = MongoFilterGenerator.GetEqualsFilter("username", data.Username.ToLower());
                 userDocs = dbServce.GetFilteredUsers(usernameFilter);
             } catch (Exception)
             {

--- a/BEIMA.Backend/UserFunctions/AddUser.cs
+++ b/BEIMA.Backend/UserFunctions/AddUser.cs
@@ -49,6 +49,9 @@ namespace BEIMA.Backend.UserFunctions
                     return new BadRequestObjectResult(Resources.InvalidPasswordMessage);
                 }
 
+                // Enforce username case insensitivity
+                data.Username = data.Username.ToLower();
+
                 // Check for username uniqueness
                 var filter = MongoFilterGenerator.GetEqualsFilter("username", data.Username);
                 if(mongo.GetFilteredUsers(filter).Count > 0)

--- a/BEIMA.Backend/UserFunctions/UpdateUser.cs
+++ b/BEIMA.Backend/UserFunctions/UpdateUser.cs
@@ -62,6 +62,10 @@ namespace BEIMA.Backend.UserFunctions
                 }
                 var originalUserRecord = BsonSerializer.Deserialize<User>(originalUserDoc);
 
+                // Enforce username case insensitivity
+                originalUserRecord.Username = originalUserRecord.Username.ToLower();
+                updatedUserRecord.Username = updatedUserRecord.Username.ToLower();
+
                 // Check for username uniqueness
                 if (originalUserRecord.Username != updatedUserRecord.Username)
                 {


### PR DESCRIPTION
<!--
These comments inside these brackets will not appear in the pull request.

The pull request should be linked to either:
 - a task (i.e., use 'Closes #TaskID' or 'Resolves #TaskID')
 - a bug (i.e., use 'Closes #BugID' or 'Fixes #BugID')

For more details, see: https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes #403

This PR implements case insensitivity for usernames. This involved modifying the AddUser, UpdateUser, and Login endpoints to handle case insensitivity.
