### PR TITLE
User endpoint authentication

### DIFF
--- a/BEIMA.Backend.FT/DeviceFT.cs
+++ b/BEIMA.Backend.FT/DeviceFT.cs
@@ -559,7 +559,7 @@ namespace BEIMA.Backend.FT
 
                 Assert.That(device.LastModified, Is.Not.Null);
                 Assert.That(device.LastModified?.Date, Is.Not.Null);
-                Assert.That(device.LastModified?.User, Is.EqualTo("Anonymous"));
+                Assert.That(device.LastModified?.User, Is.EqualTo(TestUsername));
 
                 Assert.That(device.Fields?.Single().Key, Is.EqualTo(expectedDevice.Fields?.Single().Key));
                 Assert.That(device.Fields?.Single().Value, Is.EqualTo(expectedDevice.Fields?.Single().Value));

--- a/BEIMA.Backend.FT/UserFT.cs
+++ b/BEIMA.Backend.FT/UserFT.cs
@@ -244,7 +244,7 @@ namespace BEIMA.Backend.FT
 
             Assert.That(getUser.LastModified, Is.Not.Null);
             Assert.That(getUser.LastModified?.Date, Is.Not.Null);
-            Assert.That(getUser.LastModified?.User, Is.EqualTo("Anonymous"));
+            Assert.That(getUser.LastModified?.User, Is.EqualTo(TestUsername));
         }
 
         [Test]

--- a/BEIMA.Backend.FT/UserFT.cs
+++ b/BEIMA.Backend.FT/UserFT.cs
@@ -11,13 +11,15 @@ namespace BEIMA.Backend.FT
     [TestFixture]
     public class UserFT : FunctionalTestBase
     {
+        #region SetUp and TearDown
+
         [SetUp]
         public async Task SetUp()
         {
             // Have at least one admin user in the DB at all times
             // since DeleteUser prevents deletion when there is not at least one admin user.
             var initialUserList = await TestClient.GetUserList();
-            if(!initialUserList.Any(user => user.Username == "first.admin"))
+            if (!initialUserList.Any(user => user.Username == "first.admin"))
             {
                 var adminUser = new User
                 {
@@ -44,6 +46,10 @@ namespace BEIMA.Backend.FT
             }
         }
 
+        #endregion SetUp and TearDown
+
+        #region User GET Tests
+
         [TestCase("xxx")]
         [TestCase("1234")]
         [TestCase("1234567890abcdef1234567x")]
@@ -66,6 +72,26 @@ namespace BEIMA.Backend.FT
             Assert.IsNotNull(ex);
             Assert.That(ex?.StatusCode, Is.EqualTo(HttpStatusCode.NotFound));
         }
+
+        [TestCase("1234", true)]
+        [TestCase("1234", false)]
+        [TestCase("1234567890abcdef1234567x", true)]
+        [TestCase("1234567890abcdef1234567x", false)]
+        [TestCase("1234567890abcdef12345678", true)]
+        [TestCase("1234567890abcdef12345678", false)]
+        public void NotAuthorized_UserGet_ReturnsUnauthorized(string id, bool isNonAdmin)
+        {
+            var ex = Assert.ThrowsAsync<BeimaException>(async () =>
+                await (isNonAdmin ? NonAdminTestClient : UnauthorizedTestClient).GetUser(id)
+            );
+            Assert.IsNotNull(ex);
+            Assert.That(ex?.Message, Does.Contain("Invalid credentials."));
+            Assert.That(ex?.StatusCode, Is.EqualTo(HttpStatusCode.Unauthorized));
+        }
+
+        #endregion User GET Tests
+
+        #region User Add Tests
 
         [Test]
         public async Task UserNotInDatabase_AddUser_CreatesNewUser()
@@ -99,6 +125,59 @@ namespace BEIMA.Backend.FT
             Assert.That(getUser.LastModified?.Date, Is.Not.Null);
             Assert.That(getUser.LastModified?.User, Is.EqualTo("Anonymous"));
         }
+
+        [Test]
+        public async Task UserInDatabase_AddUserWithDuplicateUsername_ConflictObjectResultReturned()
+        {
+            // ARRANGE
+            var user = new User
+            {
+                Username = "user.name",
+                Password = "Abcdefg12345!",
+                FirstName = "Alex",
+                LastName = "Smith",
+                Role = "user"
+            };
+            await TestClient.AddUser(user);
+
+            // ACT
+            var ex = Assert.ThrowsAsync<BeimaException>(async () =>
+                await TestClient.AddUser(user)
+            );
+
+            // ASSERT
+            Assert.That(ex, Is.Not.Null);
+            Assert.That(ex?.StatusCode, Is.EqualTo(HttpStatusCode.Conflict));
+        }
+
+        [TestCase(true)]
+        [TestCase(false)]
+        public void UnauthorizedUser_AddUser_ReturnsUnauthorized(bool isNonAdmin)
+        {
+            // ARRANGE
+            var user = new User
+            {
+                Username = "user.name",
+                Password = "Abcdefg12345!",
+                FirstName = "Alex",
+                LastName = "Smith",
+                Role = "user"
+            };
+
+            // ACT
+            var ex = Assert.ThrowsAsync<BeimaException>(async () =>
+                await (isNonAdmin ? NonAdminTestClient : UnauthorizedTestClient).AddUser(user)
+            );
+
+            // ASSERT
+            Assert.IsNotNull(ex);
+            Assert.That(ex?.Message, Does.Contain("Invalid credentials."));
+            Assert.That(ex?.StatusCode, Is.EqualTo(HttpStatusCode.Unauthorized));
+        }
+
+        #endregion User Add Tests
+
+        #region User List Tests
 
         [Test]
         public async Task UsersInDatabase_GetUserList_ReturnsUserList()
@@ -148,7 +227,7 @@ namespace BEIMA.Backend.FT
             foreach (var user in actualUsers)
             {
                 // Skip the "first.admin" user since we assume it will always be in there.
-                if(user.Username != "first.admin")
+                if (user.Username != "first.admin")
                 {
                     Assert.That(user, Is.Not.Null);
                     var expectedUser = userList.Single(b => b.Id?.Equals(user.Id) ?? false);
@@ -165,6 +244,59 @@ namespace BEIMA.Backend.FT
                 }
             }
         }
+
+        [TestCase(true)]
+        [TestCase(false)]
+        public async Task UnauthorizedUser_GetUserList_ReturnsAnauthorized(bool isNonAdmin)
+        {
+            // ARRANGE
+            var userList = new List<User>
+            {
+                new User
+                {
+                    Username = "user.name1",
+                    Password = "Abcdefg12345!1",
+                    FirstName = "Alex",
+                    LastName = "Smith",
+                    Role = "user"
+                },
+                new User
+                {
+                    Username = "user.name2",
+                    Password = "Abcdefg12345!2",
+                    FirstName = "Ali",
+                    LastName = "Glenn",
+                    Role = "user"
+                },
+                new User
+                {
+                    Username = "user.name3",
+                    Password = "Abcdefg12345!3",
+                    FirstName = "Aaron",
+                    LastName = "Bart",
+                    Role = "user"
+                }
+            };
+
+            foreach (var user in userList)
+            {
+                user.Id = await TestClient.AddUser(user);
+            }
+
+            // ACT
+            var ex = Assert.ThrowsAsync<BeimaException>(async () =>
+                await (isNonAdmin ? NonAdminTestClient : UnauthorizedTestClient).GetUserList()
+            );
+
+            // ASSERT
+            Assert.IsNotNull(ex);
+            Assert.That(ex?.Message, Does.Contain("Invalid credentials."));
+            Assert.That(ex?.StatusCode, Is.EqualTo(HttpStatusCode.Unauthorized));
+        }
+
+        #endregion User List Tests
+
+        #region User Delete Tests
 
         [Test]
         public async Task UserInDatabase_DeleteUser_UserDeletedSuccessfully()
@@ -189,6 +321,40 @@ namespace BEIMA.Backend.FT
             var ex = Assert.ThrowsAsync<BeimaException>(async () => await TestClient.GetUser(userId));
             Assert.That(ex?.StatusCode, Is.EqualTo(HttpStatusCode.NotFound));
         }
+
+        [TestCase(true)]
+        [TestCase(false)]
+        public async Task UnauthorizedUser_DeleteUser_ReturnsUnauthorized(bool isNonAdmin)
+        {
+            // ARRANGE
+            var user = new User
+            {
+                Username = "user.name",
+                Password = "Abcdefg12345!",
+                FirstName = "Alex",
+                LastName = "Smith",
+                Role = "user"
+            };
+
+            var userId = await TestClient.AddUser(user);
+            Assume.That(await TestClient.GetUser(userId), Is.Not.Null);
+
+            // ACT
+            var ex = Assert.ThrowsAsync<BeimaException>(async () =>
+                await (isNonAdmin ? NonAdminTestClient : UnauthorizedTestClient).DeleteUser(userId)
+            );
+
+            // ASSERT
+            Assert.DoesNotThrowAsync(async () => await TestClient.GetUser(userId));
+
+            Assert.IsNotNull(ex);
+            Assert.That(ex?.Message, Does.Contain("Invalid credentials."));
+            Assert.That(ex?.StatusCode, Is.EqualTo(HttpStatusCode.Unauthorized));
+        }
+
+        #endregion User Delete Tests
+
+        #region User Update Tests
 
         [Test]
         public async Task UserInDatabase_UpdateUserWithPasswordAndTryLogin_ReturnsUpdatedUserAndSuccessfulLogin()
@@ -242,7 +408,7 @@ namespace BEIMA.Backend.FT
             // ASSERT
             Assert.That(updatedUser, Is.Not.Null);
             Assert.That(updatedUser.FirstName, Is.Not.EqualTo(origUser.FirstName));
-            
+
             Assert.That(updatedUser.Id, Is.EqualTo(updateItem.Id));
             Assert.That(updatedUser.Username, Is.EqualTo(updateItem.Username));
             Assert.That(updatedUser.LastName, Is.EqualTo(updateItem.LastName));
@@ -276,7 +442,7 @@ namespace BEIMA.Backend.FT
                 Password = origUser.Password
             };
             var originalToken = await TestClient.Login(originalLoginRequest);
-            
+
             Assume.That(origItem, Is.Not.Null);
             Assume.That(originalToken, Is.Not.Null);
             Assume.That(originalToken, Is.Not.EqualTo(string.Empty));
@@ -313,30 +479,6 @@ namespace BEIMA.Backend.FT
 
             Assert.That(newToken, Is.Not.Null);
             Assert.That(newToken, Is.Not.EqualTo(string.Empty));
-        }
-
-        [Test]
-        public async Task UserInDatabase_AddUserWithDuplicateUsername_ConflictObjectResultReturned()
-        {
-            // ARRANGE
-            var user = new User
-            {
-                Username = "user.name",
-                Password = "Abcdefg12345!",
-                FirstName = "Alex",
-                LastName = "Smith",
-                Role = "user"
-            };
-            await TestClient.AddUser(user);
-
-            // ACT
-            var ex = Assert.ThrowsAsync<BeimaException>(async () =>
-                await TestClient.AddUser(user)
-            );
-
-            // ASSERT
-            Assert.That(ex, Is.Not.Null);
-            Assert.That(ex?.StatusCode, Is.EqualTo(HttpStatusCode.Conflict));
         }
 
         [Test]
@@ -388,5 +530,57 @@ namespace BEIMA.Backend.FT
             Assert.That(ex, Is.Not.Null);
             Assert.That(ex?.StatusCode, Is.EqualTo(HttpStatusCode.Conflict));
         }
+
+        [TestCase(true)]
+        [TestCase(false)]
+        public async Task UnauthorizedUser_UpdateUserWithPassword_ReturnsUnauthorized(bool isNonAdmin)
+        {
+            // ARRANGE
+            var origUser = new User
+            {
+                Username = "user.name",
+                Password = "Abcdefg12345!",
+                FirstName = "Alex",
+                LastName = "Smith",
+                Role = "user"
+            };
+
+            var userId = await TestClient.AddUser(origUser);
+            var origItem = await TestClient.GetUser(userId);
+
+            // Verify login works with current password.
+            var originalLoginRequest = new LoginRequest
+            {
+                Username = origUser.Username,
+                Password = origUser.Password
+            };
+            var originalToken = await TestClient.Login(originalLoginRequest);
+
+            Assume.That(origItem, Is.Not.Null);
+            Assume.That(originalToken, Is.Not.Null);
+            Assume.That(originalToken, Is.Not.EqualTo(string.Empty));
+
+            var updateItem = new User
+            {
+                Id = userId,
+                Username = "user.name",
+                Password = "NewPassword123!",
+                FirstName = "Alexis",
+                LastName = "Smith",
+                Role = "user"
+            };
+
+            // ACT
+            var ex = Assert.ThrowsAsync<BeimaException>(async () =>
+                await (isNonAdmin ? NonAdminTestClient : UnauthorizedTestClient).UpdateUser(updateItem)
+            );
+
+            // ASSERT
+            Assert.IsNotNull(ex);
+            Assert.That(ex?.Message, Does.Contain("Invalid credentials."));
+            Assert.That(ex?.StatusCode, Is.EqualTo(HttpStatusCode.Unauthorized));
+        }
+
+        #endregion User Update Tests
     }
 }

--- a/BEIMA.Backend.FT/UserFT.cs
+++ b/BEIMA.Backend.FT/UserFT.cs
@@ -123,7 +123,7 @@ namespace BEIMA.Backend.FT
 
             Assert.That(getUser.LastModified, Is.Not.Null);
             Assert.That(getUser.LastModified?.Date, Is.Not.Null);
-            Assert.That(getUser.LastModified?.User, Is.EqualTo("Anonymous"));
+            Assert.That(getUser.LastModified?.User, Is.EqualTo(TestUsername));
         }
 
         [Test]
@@ -240,7 +240,7 @@ namespace BEIMA.Backend.FT
 
                     Assert.That(user.LastModified, Is.Not.Null);
                     Assert.That(user.LastModified?.Date, Is.Not.Null);
-                    Assert.That(user.LastModified?.User, Is.EqualTo("Anonymous"));
+                    Assert.That(user.LastModified?.User, Is.EqualTo(TestUsername));
                 }
             }
         }

--- a/BEIMA.Backend.Test/UserFunctions/UpdateUserTest.cs
+++ b/BEIMA.Backend.Test/UserFunctions/UpdateUserTest.cs
@@ -11,6 +11,9 @@ using System.Threading.Tasks;
 using static BEIMA.Backend.Test.RequestFactory;
 using MongoDB.Driver;
 using System.Collections.Generic;
+using BEIMA.Backend.AuthService;
+using Microsoft.AspNetCore.Http;
+using BEIMA.Backend.Models;
 
 namespace BEIMA.Backend.Test.UserFunctions
 {
@@ -31,6 +34,12 @@ namespace BEIMA.Backend.Test.UserFunctions
                   .Verifiable();
             MongoDefinition.MongoInstance = mockDb.Object;
 
+            Mock<IAuthenticationService> mockAuth = new Mock<IAuthenticationService>();
+            mockAuth.Setup(mock => mock.ParseToken(It.IsAny<HttpRequest>()))
+                .Returns(new Claims { Role = Constants.ADMIN_ROLE, Username = "Bob" })
+                .Verifiable();
+            AuthenticationDefinition.AuthenticationInstance = mockAuth.Object;
+
             var request = CreateHttpRequest(RequestMethod.POST, body: TestData._testUpdateUserWithPassword);
             var logger = (new LoggerFactory()).CreateLogger("Testing");
 
@@ -38,6 +47,7 @@ namespace BEIMA.Backend.Test.UserFunctions
             var response = await UpdateUser.Run(request, testId, logger);
 
             // ASSERT
+            Assert.DoesNotThrow(() => mockAuth.Verify(mock => mock.ParseToken(It.IsAny<HttpRequest>()), Times.Once));
             Assert.DoesNotThrow(() => mockDb.Verify(mock => mock.GetUser(It.IsAny<ObjectId>()), Times.Once));
             Assert.DoesNotThrow(() => mockDb.Verify(mock => mock.UpdateUser(It.IsAny<BsonDocument>()), Times.Never));
 
@@ -59,6 +69,12 @@ namespace BEIMA.Backend.Test.UserFunctions
                   .Verifiable();
             MongoDefinition.MongoInstance = mockDb.Object;
 
+            Mock<IAuthenticationService> mockAuth = new Mock<IAuthenticationService>();
+            mockAuth.Setup(mock => mock.ParseToken(It.IsAny<HttpRequest>()))
+                .Returns(new Claims { Role = Constants.ADMIN_ROLE, Username = "Bob" })
+                .Verifiable();
+            AuthenticationDefinition.AuthenticationInstance = mockAuth.Object;
+
             var request = CreateHttpRequest(RequestMethod.POST, body: TestData._testUpdateUserWithPassword);
             var logger = (new LoggerFactory()).CreateLogger("Testing");
 
@@ -66,6 +82,7 @@ namespace BEIMA.Backend.Test.UserFunctions
             var response = await UpdateUser.Run(request, id, logger);
 
             // ASSERT
+            Assert.DoesNotThrow(() => mockAuth.Verify(mock => mock.ParseToken(It.IsAny<HttpRequest>()), Times.Once));
             Assert.DoesNotThrow(() => mockDb.Verify(mock => mock.UpdateUser(It.IsAny<BsonDocument>()), Times.Never));
 
             Assert.That(response, Is.TypeOf(typeof(BadRequestObjectResult)));
@@ -91,6 +108,12 @@ namespace BEIMA.Backend.Test.UserFunctions
                   .Verifiable();
             MongoDefinition.MongoInstance = mockDb.Object;
 
+            Mock<IAuthenticationService> mockAuth = new Mock<IAuthenticationService>();
+            mockAuth.Setup(mock => mock.ParseToken(It.IsAny<HttpRequest>()))
+                .Returns(new Claims { Role = Constants.ADMIN_ROLE, Username = "Bob" })
+                .Verifiable();
+            AuthenticationDefinition.AuthenticationInstance = mockAuth.Object;
+
             var body = TestData._testUpdateUserWithPassword;
             var request = CreateHttpRequest(RequestMethod.POST, body: body);
             var logger = (new LoggerFactory()).CreateLogger("Testing");
@@ -99,6 +122,7 @@ namespace BEIMA.Backend.Test.UserFunctions
             var response = await UpdateUser.Run(request, testId, logger);
 
             // ASSERT
+            Assert.DoesNotThrow(() => mockAuth.Verify(mock => mock.ParseToken(It.IsAny<HttpRequest>()), Times.Once));
             Assert.DoesNotThrow(() => mockDb.Verify(mock => mock.GetUser(It.IsAny<ObjectId>()), Times.Once));
             Assert.DoesNotThrow(() => mockDb.Verify(mock => mock.UpdateUser(It.IsAny<BsonDocument>()), Times.Once));
 
@@ -131,6 +155,12 @@ namespace BEIMA.Backend.Test.UserFunctions
                   .Verifiable();
             MongoDefinition.MongoInstance = mockDb.Object;
 
+            Mock<IAuthenticationService> mockAuth = new Mock<IAuthenticationService>();
+            mockAuth.Setup(mock => mock.ParseToken(It.IsAny<HttpRequest>()))
+                .Returns(new Claims { Role = Constants.ADMIN_ROLE, Username = "Bob" })
+                .Verifiable();
+            AuthenticationDefinition.AuthenticationInstance = mockAuth.Object;
+
             var body = TestData._testUpdateUserWithoutPassword;
             var request = CreateHttpRequest(RequestMethod.POST, body: body);
             var logger = (new LoggerFactory()).CreateLogger("Testing");
@@ -139,6 +169,7 @@ namespace BEIMA.Backend.Test.UserFunctions
             var response = await UpdateUser.Run(request, testId, logger);
 
             // ASSERT
+            Assert.DoesNotThrow(() => mockAuth.Verify(mock => mock.ParseToken(It.IsAny<HttpRequest>()), Times.Once));
             Assert.DoesNotThrow(() => mockDb.Verify(mock => mock.GetUser(It.IsAny<ObjectId>()), Times.Once));
             Assert.DoesNotThrow(() => mockDb.Verify(mock => mock.UpdateUser(It.IsAny<BsonDocument>()), Times.Once));
 
@@ -174,6 +205,12 @@ namespace BEIMA.Backend.Test.UserFunctions
                   .Verifiable();
             MongoDefinition.MongoInstance = mockDb.Object;
 
+            Mock<IAuthenticationService> mockAuth = new Mock<IAuthenticationService>();
+            mockAuth.Setup(mock => mock.ParseToken(It.IsAny<HttpRequest>()))
+                .Returns(new Claims { Role = Constants.ADMIN_ROLE, Username = "Bob" })
+                .Verifiable();
+            AuthenticationDefinition.AuthenticationInstance = mockAuth.Object;
+
             var body = TestData._testUserBadPassword.Replace("---", badPassword);
             var request = CreateHttpRequest(RequestMethod.POST, body: body);
             var logger = (new LoggerFactory()).CreateLogger("Testing");
@@ -182,6 +219,7 @@ namespace BEIMA.Backend.Test.UserFunctions
             var response = await UpdateUser.Run(request, testId, logger);
 
             // ASSERT
+            Assert.DoesNotThrow(() => mockAuth.Verify(mock => mock.ParseToken(It.IsAny<HttpRequest>()), Times.Once));
             Assert.DoesNotThrow(() => mockDb.Verify(mock => mock.GetUser(It.IsAny<ObjectId>()), Times.Once));
             Assert.DoesNotThrow(() => mockDb.Verify(mock => mock.UpdateUser(It.IsAny<BsonDocument>()), Times.Never));
 
@@ -216,6 +254,12 @@ namespace BEIMA.Backend.Test.UserFunctions
                   .Verifiable();
             MongoDefinition.MongoInstance = mockDb.Object;
 
+            Mock<IAuthenticationService> mockAuth = new Mock<IAuthenticationService>();
+            mockAuth.Setup(mock => mock.ParseToken(It.IsAny<HttpRequest>()))
+                .Returns(new Claims { Role = Constants.ADMIN_ROLE, Username = "Bob" })
+                .Verifiable();
+            AuthenticationDefinition.AuthenticationInstance = mockAuth.Object;
+
             var body = TestData._testUserDuplicateUsername.Replace("---", username);
             var request = CreateHttpRequest(RequestMethod.POST, body: body);
             var logger = (new LoggerFactory()).CreateLogger("Testing");
@@ -224,6 +268,7 @@ namespace BEIMA.Backend.Test.UserFunctions
             var response = (ObjectResult)await UpdateUser.Run(request, testId, logger);
 
             // ASSERT
+            Assert.DoesNotThrow(() => mockAuth.Verify(mock => mock.ParseToken(It.IsAny<HttpRequest>()), Times.Once));
             Assert.DoesNotThrow(() => mockDb.Verify(mock => mock.GetUser(It.IsAny<ObjectId>()), Times.Once));
             Assert.DoesNotThrow(() => mockDb.Verify(mock => mock.GetFilteredUsers(It.IsAny<FilterDefinition<BsonDocument>>()), Times.Once));
             Assert.DoesNotThrow(() => mockDb.Verify(mock => mock.UpdateUser(It.IsAny<BsonDocument>()), Times.Never));
@@ -232,6 +277,44 @@ namespace BEIMA.Backend.Test.UserFunctions
             Assert.That(response, Is.TypeOf(typeof(ConflictObjectResult)));
             Assert.That(response.StatusCode, Is.EqualTo((int)HttpStatusCode.Conflict));
             Assert.That(response.Value?.ToString(), Is.EqualTo("Username already exists."));
+        }
+
+        [TestCaseSource(nameof(ClaimsFactory))]
+        public async Task InvalidCredentials_UpdateUser_ReturnsUnauthorized(Claims claim)
+        {
+            // ARRANGE
+            var testId = "abcdef123456789012345678";
+
+            Mock<IMongoConnector> mockDb = new Mock<IMongoConnector>();
+            MongoDefinition.MongoInstance = mockDb.Object;
+
+            Mock<IAuthenticationService> mockAuth = new Mock<IAuthenticationService>();
+            mockAuth.Setup(mock => mock.ParseToken(It.IsAny<HttpRequest>()))
+                .Returns(claim)
+                .Verifiable();
+            AuthenticationDefinition.AuthenticationInstance = mockAuth.Object;
+
+            var body = TestData._testUpdateUserWithPassword;
+            var request = CreateHttpRequest(RequestMethod.POST, body: body);
+            var logger = (new LoggerFactory()).CreateLogger("Testing");
+
+            // ACT
+            var response = (ObjectResult)await UpdateUser.Run(request, testId, logger);
+
+            // ASSERT
+            Assert.DoesNotThrow(() => mockAuth.Verify(mock => mock.ParseToken(It.IsAny<HttpRequest>()), Times.Once));
+            Assert.DoesNotThrow(() => mockDb.Verify(mock => mock.GetUser(It.IsAny<ObjectId>()), Times.Never));
+            Assert.DoesNotThrow(() => mockDb.Verify(mock => mock.UpdateUser(It.IsAny<BsonDocument>()), Times.Never));
+
+            Assert.That(response, Is.Not.Null);
+            Assert.That(response.StatusCode, Is.EqualTo((int)HttpStatusCode.Unauthorized));
+            Assert.That(response.Value, Is.EqualTo("Invalid credentials."));
+        }
+
+        private static IEnumerable<Claims?> ClaimsFactory()
+        {
+            yield return null;
+            yield return new Claims { Role = "nonadmin", Username = "Bob" };
         }
     }
 }

--- a/BEIMA.Backend/AuthService/IAuthenticationService.cs
+++ b/BEIMA.Backend/AuthService/IAuthenticationService.cs
@@ -1,11 +1,6 @@
 ﻿using BEIMA.Backend.Models;
 using BEIMA.Backend.MongoService;
 using Microsoft.AspNetCore.Http;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace BEIMA.Backend.AuthService
 {
@@ -20,12 +15,13 @@ namespace BEIMA.Backend.AuthService
         /// <param name="user"></param>
         /// <returns>string encoding of a JWT token</returns>
         string CreateToken(User user);
+
         /// <summary>
         /// Parses the headers of an HttpRequest for
         /// a JWT and returnes the claims found inside of it
         /// </summary>
         /// <param name="req"></param>
         /// <returns>JWT claims</returns>
-        Claims ParseToken(HttpRequest req);        
+        Claims ParseToken(HttpRequest req);
     }
 }

--- a/BEIMA.Backend/Constants.cs
+++ b/BEIMA.Backend/Constants.cs
@@ -4,5 +4,6 @@
     {
         public const int MAX_CHARACTER_LENGTH = 1024;
         public const string PASSWORD_REGEX = "^(?=.*?[A-Z])(?=.*?[a-z])(?=.*?[0-9])(?=.*?[#?!@$%^&*-]).{8,}$";
+        public const string ADMIN_ROLE = "admin";
     }
 }

--- a/BEIMA.Backend/DeviceFunctions/AddDevice.cs
+++ b/BEIMA.Backend/DeviceFunctions/AddDevice.cs
@@ -38,7 +38,7 @@ namespace BEIMA.Backend.DeviceFunctions
             var authService = AuthenticationDefinition.AuthenticationInstance;
             var claims = authService.ParseToken(req);
 
-            if(claims == null)
+            if (claims == null)
             {
                 return new ObjectResult(Resources.UnauthorizedMessage) { StatusCode = 401 };
             }
@@ -103,7 +103,7 @@ namespace BEIMA.Backend.DeviceFunctions
             {
                 return new BadRequestObjectResult(Resources.CouldNotParseBody);
             }
-            // TODO: Use actual user.
+
             device.SetLastModified(DateTime.UtcNow, claims.Username);
 
             // Store attached files and add file uid to device

--- a/BEIMA.Backend/UserFunctions/GetUser.cs
+++ b/BEIMA.Backend/UserFunctions/GetUser.cs
@@ -1,4 +1,5 @@
-﻿using BEIMA.Backend.MongoService;
+﻿using BEIMA.Backend.AuthService;
+using BEIMA.Backend.MongoService;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Azure.WebJobs;
@@ -28,6 +29,14 @@ namespace BEIMA.Backend.UserFunctions
             ILogger log)
         {
             log.LogInformation("C# HTTP trigger function processed a user GET request.");
+
+            // Verify JWT token
+            var authService = AuthenticationDefinition.AuthenticationInstance;
+            var claims = authService.ParseToken(req);
+            if (claims == null || !claims.Role.Equals(Constants.ADMIN_ROLE))
+            {
+                return new ObjectResult(Resources.UnauthorizedMessage) { StatusCode = StatusCodes.Status401Unauthorized };
+            }
 
             // Check if the id is valid.
             if (string.IsNullOrEmpty(id) || !ObjectId.TryParse(id, out _))

--- a/BEIMA.Backend/UserFunctions/GetUserList.cs
+++ b/BEIMA.Backend/UserFunctions/GetUserList.cs
@@ -1,4 +1,5 @@
-﻿using BEIMA.Backend.MongoService;
+﻿using BEIMA.Backend.AuthService;
+using BEIMA.Backend.MongoService;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Azure.WebJobs;
@@ -26,6 +27,14 @@ namespace BEIMA.Backend.UserFunctions
             ILogger log)
         {
             log.LogInformation("C# HTTP trigger function processed a user list request.");
+
+            // Verify JWT token
+            var authService = AuthenticationDefinition.AuthenticationInstance;
+            var claims = authService.ParseToken(req);
+            if (claims == null || !claims.Role.Equals(Constants.ADMIN_ROLE))
+            {
+                return new ObjectResult(Resources.UnauthorizedMessage) { StatusCode = StatusCodes.Status401Unauthorized };
+            }
 
             var mongo = MongoDefinition.MongoInstance;
             var users = mongo.GetAllUsers();

--- a/BEIMA.Backend/UserFunctions/UpdateUser.cs
+++ b/BEIMA.Backend/UserFunctions/UpdateUser.cs
@@ -1,20 +1,20 @@
-﻿using System;
-using System.IO;
-using System.Threading.Tasks;
+﻿using BEIMA.Backend.AuthService;
+using BEIMA.Backend.Models;
+using BEIMA.Backend.MongoService;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Azure.WebJobs;
 using Microsoft.Azure.WebJobs.Extensions.Http;
-using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
-using Newtonsoft.Json;
 using MongoDB.Bson;
-using BEIMA.Backend.MongoService;
 using MongoDB.Bson.Serialization;
-using BEIMA.Backend.Models;
+using Newtonsoft.Json;
+using System;
+using System.IO;
 using System.Net;
-using BCryptNet = BCrypt.Net.BCrypt;
-using System.Linq;
 using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using BCryptNet = BCrypt.Net.BCrypt;
 
 namespace BEIMA.Backend.UserFunctions
 {
@@ -37,6 +37,14 @@ namespace BEIMA.Backend.UserFunctions
             ILogger log)
         {
             log.LogInformation("C# HTTP trigger function processed a user update request.");
+
+            // Verify JWT token
+            var authService = AuthenticationDefinition.AuthenticationInstance;
+            var claims = authService.ParseToken(req);
+            if (claims == null || !claims.Role.Equals(Constants.ADMIN_ROLE))
+            {
+                return new ObjectResult(Resources.UnauthorizedMessage) { StatusCode = StatusCodes.Status401Unauthorized };
+            }
 
             if (!ObjectId.TryParse(id, out _))
             {
@@ -96,8 +104,7 @@ namespace BEIMA.Backend.UserFunctions
                 return new BadRequestObjectResult(Resources.CouldNotParseBody);
             }
 
-            // TODO: Use actual username when authentication is implemented.
-            user.SetLastModified(DateTime.UtcNow, "Anonymous");
+            user.SetLastModified(DateTime.UtcNow, claims.Username);
 
             string message;
             HttpStatusCode statusCode;


### PR DESCRIPTION
<!--
These comments inside these brackets will not appear in the pull request.

The pull request should be linked to either:
 - a task (i.e., use 'Closes #TaskID' or 'Resolves #TaskID')
 - a bug (i.e., use 'Closes #BugID' or 'Fixes #BugID')

For more details, see: https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes #408

This adds authentication to all of the user endpoints. This also updates the application to create a default admin user on startup of the backend via the mongo connector if an admin user does not exist in the current database. The functional tests have also been updated to adapt to this change.
