### PR TITLE
added capitalization to warnings

### DIFF
--- a/BEIMA.Client/src/pages/DeviceTypes/DeviceTypePage.js
+++ b/BEIMA.Client/src/pages/DeviceTypes/DeviceTypePage.js
@@ -115,7 +115,6 @@ const DeviceTypePage = () => {
       
       Object.entries(result).forEach(entry => {
         const [key, value] = entry;
-        console.log([key, value]);
         if(value === ""){
           let capitalize = key.split(/(?=[A-Z])/);
           

--- a/BEIMA.Client/src/pages/DeviceTypes/DeviceTypePage.js
+++ b/BEIMA.Client/src/pages/DeviceTypes/DeviceTypePage.js
@@ -115,8 +115,15 @@ const DeviceTypePage = () => {
       
       Object.entries(result).forEach(entry => {
         const [key, value] = entry;
+        console.log([key, value]);
         if(value === ""){
-          warnings.push(`"${key}" field is empty<br/>`);
+          let capitalize = key.split(/(?=[A-Z])/);
+          
+          for(let i = 0; i < capitalize.length; i++) {
+            capitalize[i] = (capitalize[i][0].toUpperCase() + capitalize[i].slice(1)).replace('Num', 'Number');
+          }
+          
+          warnings.push(`"${(capitalize).join(" ")}" field is empty<br/>`);
         }
       });
       


### PR DESCRIPTION
<!--
These comments inside these brackets will not appear in the pull request.

The pull request should be linked to either:
 - a task (i.e., use 'Closes #TaskID' or 'Resolves #TaskID')
 - a bug (i.e., use 'Closes #BugID' or 'Fixes #BugID')

For more details, see: https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes #463

Added capitalization to fields names on warning messages

Now it's:
![deviceType - no desc no notes - FIXED](https://user-images.githubusercontent.com/46760776/163635523-17680ab0-d31f-4798-8c2a-e2b3f237ffe0.jpg)


instead of

![deviceType - no desc no notes](https://user-images.githubusercontent.com/46760776/163635531-1b4e7c66-2657-47b6-aa54-963a932fb3ba.jpg)

