### PR TITLE
#407 building endpoint auth

### DIFF
--- a/BEIMA.Backend.FT/BuildingFT.cs
+++ b/BEIMA.Backend.FT/BuildingFT.cs
@@ -79,6 +79,7 @@ namespace BEIMA.Backend.FT
             Assert.That(ex?.StatusCode, Is.EqualTo(HttpStatusCode.NotFound));
         }
 
+        [Test]
         public void NoBuildingsInDatabase_Unauthorized_BuildingGet_ReturnsUnauthorized()
         {
             var ex = Assert.ThrowsAsync<BeimaException>(async () =>
@@ -89,6 +90,7 @@ namespace BEIMA.Backend.FT
             Assert.That(ex?.StatusCode, Is.EqualTo(HttpStatusCode.Unauthorized));
         }
 
+        [Test]
         public void NoBuildingsInDatabase_Unauthorized_BuildingGet_EmptyId_ReturnsNotFound()
         {
             var ex = Assert.ThrowsAsync<BeimaException>(async () =>

--- a/BEIMA.Backend.FT/BuildingFT.cs
+++ b/BEIMA.Backend.FT/BuildingFT.cs
@@ -79,16 +79,23 @@ namespace BEIMA.Backend.FT
             Assert.That(ex?.StatusCode, Is.EqualTo(HttpStatusCode.NotFound));
         }
 
-        [TestCase("")]
-        [TestCase("1234567890abcdef12345678")]
-        public void NoBuildingsInDatabase_Unauthorized__BuildingGet_ReturnsUnauthorized(string id)
+        public void NoBuildingsInDatabase_Unauthorized_BuildingGet_ReturnsUnauthorized(string id)
         {
             var ex = Assert.ThrowsAsync<BeimaException>(async () =>
-                await UnauthorizedTestClient.GetBuilding(id)
+                await UnauthorizedTestClient.GetBuilding("1234567890abcdef12345678")
             );
             Assert.IsNotNull(ex);
             Assert.That(ex?.Message, Does.Contain("Invalid credentials."));
             Assert.That(ex?.StatusCode, Is.EqualTo(HttpStatusCode.Unauthorized));
+        }
+
+        public void NoBuildingsInDatabase_Unauthorized_BuildingGet_EmptyId_ReturnsNotFound()
+        {
+            var ex = Assert.ThrowsAsync<BeimaException>(async () =>
+                await UnauthorizedTestClient.GetBuilding("")
+            );
+            Assert.IsNotNull(ex);
+            Assert.That(ex?.StatusCode, Is.EqualTo(HttpStatusCode.NotFound));
         }
 
         [Test]
@@ -121,7 +128,7 @@ namespace BEIMA.Backend.FT
 
             Assert.That(getBuilding.LastModified, Is.Not.Null);
             Assert.That(getBuilding.LastModified?.Date, Is.Not.Null);
-            Assert.That(getBuilding.LastModified?.User, Is.EqualTo("Anonymous"));
+            Assert.That(getBuilding.LastModified?.User, Is.EqualTo(TestUsername));
 
             Assert.That(getBuilding.Location, Is.Not.Null);
             Assert.That(getBuilding.Location?.Latitude, Is.EqualTo(building.Location?.Latitude));
@@ -218,7 +225,7 @@ namespace BEIMA.Backend.FT
 
                 Assert.That(building.LastModified, Is.Not.Null);
                 Assert.That(building.LastModified?.Date, Is.Not.Null);
-                Assert.That(building.LastModified?.User, Is.EqualTo("Anonymous"));
+                Assert.That(building.LastModified?.User, Is.EqualTo(TestUsername));
 
                 Assert.That(building.Location, Is.Not.Null);
                 Assert.That(building.Location?.Latitude, Is.EqualTo(expectedBuilding.Location?.Latitude));
@@ -381,7 +388,7 @@ namespace BEIMA.Backend.FT
             Assert.That(updatedBuilding.Notes, Is.Not.EqualTo(origBuilding.Notes));
 
             Assert.That(updatedBuilding.LastModified?.Date, Is.Not.EqualTo(origItem.LastModified?.Date));
-            Assert.That(updatedBuilding.LastModified?.User, Is.EqualTo(origItem.LastModified?.User));
+            Assert.That(updatedBuilding.LastModified?.User, Is.EqualTo(TestUsername));
 
             Assert.That(updatedBuilding.Id, Is.EqualTo(updateItem.Id));
             Assert.That(updatedBuilding.Name, Is.EqualTo(updateItem.Name));

--- a/BEIMA.Backend.FT/BuildingFT.cs
+++ b/BEIMA.Backend.FT/BuildingFT.cs
@@ -79,7 +79,7 @@ namespace BEIMA.Backend.FT
             Assert.That(ex?.StatusCode, Is.EqualTo(HttpStatusCode.NotFound));
         }
 
-        public void NoBuildingsInDatabase_Unauthorized_BuildingGet_ReturnsUnauthorized(string id)
+        public void NoBuildingsInDatabase_Unauthorized_BuildingGet_ReturnsUnauthorized()
         {
             var ex = Assert.ThrowsAsync<BeimaException>(async () =>
                 await UnauthorizedTestClient.GetBuilding("1234567890abcdef12345678")

--- a/BEIMA.Backend.Test/BuildingFunctions/DeleteBuildingTest.cs
+++ b/BEIMA.Backend.Test/BuildingFunctions/DeleteBuildingTest.cs
@@ -1,5 +1,8 @@
-﻿using BEIMA.Backend.BuildingFunctions;
+﻿using BEIMA.Backend.AuthService;
+using BEIMA.Backend.BuildingFunctions;
+using BEIMA.Backend.Models;
 using BEIMA.Backend.MongoService;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using MongoDB.Bson;
@@ -25,6 +28,13 @@ namespace BEIMA.Backend.Test.BuildingFunctions
             Mock<IMongoConnector> mockDb = new Mock<IMongoConnector>();
             MongoDefinition.MongoInstance = mockDb.Object;
 
+            // Setup mock authentication service.
+            Mock<IAuthenticationService> mockAuth = new Mock<IAuthenticationService>();
+            mockAuth.Setup(mock => mock.ParseToken(It.IsAny<HttpRequest>()))
+                .Returns(new Claims { Role = Constants.ADMIN_ROLE, Username = "Bob" })
+                .Verifiable();
+            AuthenticationDefinition.AuthenticationInstance = mockAuth.Object;
+
             var request = CreateHttpRequest(RequestMethod.POST);
             var logger = (new LoggerFactory()).CreateLogger("Testing");
 
@@ -32,6 +42,7 @@ namespace BEIMA.Backend.Test.BuildingFunctions
             var response = DeleteBuilding.Run(request, id, logger);
 
             // ASSERT
+            Assert.DoesNotThrow(() => mockAuth.Verify(mock => mock.ParseToken(It.IsAny<HttpRequest>()), Times.Once));
             Assert.DoesNotThrow(() => mockDb.Verify(mock => mock.GetAllDevices(), Times.Never));
             Assert.DoesNotThrow(() => mockDb.Verify(mock => mock.DeleteBuilding(It.IsAny<ObjectId>()), Times.Never));
 
@@ -55,6 +66,13 @@ namespace BEIMA.Backend.Test.BuildingFunctions
                   .Verifiable();
             MongoDefinition.MongoInstance = mockDb.Object;
 
+            // Setup mock authentication service.
+            Mock<IAuthenticationService> mockAuth = new Mock<IAuthenticationService>();
+            mockAuth.Setup(mock => mock.ParseToken(It.IsAny<HttpRequest>()))
+                .Returns(new Claims { Role = Constants.ADMIN_ROLE, Username = "Bob" })
+                .Verifiable();
+            AuthenticationDefinition.AuthenticationInstance = mockAuth.Object;
+
             var request = CreateHttpRequest(RequestMethod.POST);
             var logger = (new LoggerFactory()).CreateLogger("Testing");
 
@@ -62,6 +80,7 @@ namespace BEIMA.Backend.Test.BuildingFunctions
             var response = DeleteBuilding.Run(request, testId, logger);
 
             // ASSERT
+            Assert.DoesNotThrow(() => mockAuth.Verify(mock => mock.ParseToken(It.IsAny<HttpRequest>()), Times.Once));
             Assert.DoesNotThrow(() => mockDb.Verify(mock => mock.GetFilteredDevices(It.IsAny<FilterDefinition<BsonDocument>>()), Times.Once));
             Assert.DoesNotThrow(() => mockDb.Verify(mock => mock.DeleteBuilding(It.IsAny<ObjectId>()), Times.Once));
 
@@ -88,6 +107,13 @@ namespace BEIMA.Backend.Test.BuildingFunctions
                   .Verifiable();
             MongoDefinition.MongoInstance = mockDb.Object;
 
+            // Setup mock authentication service.
+            Mock<IAuthenticationService> mockAuth = new Mock<IAuthenticationService>();
+            mockAuth.Setup(mock => mock.ParseToken(It.IsAny<HttpRequest>()))
+                .Returns(new Claims { Role = Constants.ADMIN_ROLE, Username = "Bob" })
+                .Verifiable();
+            AuthenticationDefinition.AuthenticationInstance = mockAuth.Object;
+
             var request = CreateHttpRequest(RequestMethod.GET);
             var logger = (new LoggerFactory()).CreateLogger("Testing");
 
@@ -95,6 +121,7 @@ namespace BEIMA.Backend.Test.BuildingFunctions
             var response = DeleteBuilding.Run(request, testId, logger);
 
             // ASSERT
+            Assert.DoesNotThrow(() => mockAuth.Verify(mock => mock.ParseToken(It.IsAny<HttpRequest>()), Times.Once));
             Assert.DoesNotThrow(() => mockDb.Verify(mock => mock.GetFilteredDevices(It.IsAny<FilterDefinition<BsonDocument>>()), Times.Once));
             Assert.DoesNotThrow(() => mockDb.Verify(mock => mock.DeleteBuilding(It.IsAny<ObjectId>()), Times.Never));
 
@@ -119,6 +146,13 @@ namespace BEIMA.Backend.Test.BuildingFunctions
                   .Verifiable();
             MongoDefinition.MongoInstance = mockDb.Object;
 
+            // Setup mock authentication service.
+            Mock<IAuthenticationService> mockAuth = new Mock<IAuthenticationService>();
+            mockAuth.Setup(mock => mock.ParseToken(It.IsAny<HttpRequest>()))
+                .Returns(new Claims { Role = Constants.ADMIN_ROLE, Username = "Bob" })
+                .Verifiable();
+            AuthenticationDefinition.AuthenticationInstance = mockAuth.Object;
+
             var request = CreateHttpRequest(RequestMethod.GET);
             var logger = (new LoggerFactory()).CreateLogger("Testing");
 
@@ -126,6 +160,7 @@ namespace BEIMA.Backend.Test.BuildingFunctions
             var response = DeleteBuilding.Run(request, testId, logger);
 
             // ASSERT
+            Assert.DoesNotThrow(() => mockAuth.Verify(mock => mock.ParseToken(It.IsAny<HttpRequest>()), Times.Once));
             Assert.DoesNotThrow(() => mockDb.Verify(mock => mock.GetFilteredDevices(It.IsAny<FilterDefinition<BsonDocument>>()), Times.Once));
             Assert.DoesNotThrow(() => mockDb.Verify(mock => mock.DeleteBuilding(It.IsAny<ObjectId>()), Times.Once));
 

--- a/BEIMA.Backend.Test/BuildingFunctions/GetBuildingListTest.cs
+++ b/BEIMA.Backend.Test/BuildingFunctions/GetBuildingListTest.cs
@@ -10,6 +10,7 @@ using Moq;
 using NUnit.Framework;
 using System;
 using System.Collections.Generic;
+using System.Net;
 using static BEIMA.Backend.Test.RequestFactory;
 
 namespace BEIMA.Backend.Test.BuildingFunctions
@@ -83,6 +84,59 @@ namespace BEIMA.Backend.Test.BuildingFunctions
                 Assert.That(location.Latitude, Is.EqualTo(expectedLastLoc["latitude"].AsString));
                 Assert.That(location.Longitude, Is.EqualTo(expectedLastLoc["longitude"].AsString));
             }
+        }
+
+        [Test]
+        public void PopulatedDatabase_Unauthorized_GetBuildingList_ReturnsUnauthorized()
+        {
+            // ARRANGE
+            var building1 = new Building(ObjectId.GenerateNewId(), "Student Union", "1234", "Some notes 1.");
+            var building2 = new Building(ObjectId.GenerateNewId(), "Interactive Learning Center", "4321", "Some notes 2.");
+            var building3 = new Building(ObjectId.GenerateNewId(), "Albertons Library", "2468", "Some notes 3.");
+
+            building1.SetLastModified(DateTime.UtcNow, "Anonymous");
+            building2.SetLastModified(DateTime.UtcNow, "Anonymous");
+            building3.SetLastModified(DateTime.UtcNow, "Anonymous");
+
+            building1.SetLocation("0.123", "-0.321");
+            building2.SetLocation("1.234", "-4.321");
+            building3.SetLocation("1.001", "-2.002");
+
+            var buildingList = new List<BsonDocument>
+            {
+                building1.GetBsonDocument(),
+                building2.GetBsonDocument(),
+                building3.GetBsonDocument(),
+            };
+            Mock<IMongoConnector> mockDb = new Mock<IMongoConnector>();
+            mockDb.Setup(mock => mock.GetAllBuildings())
+                  .Returns(buildingList)
+                  .Verifiable();
+            MongoDefinition.MongoInstance = mockDb.Object;
+
+            // Setup mock authentication service.
+            Mock<IAuthenticationService> mockAuth = new Mock<IAuthenticationService>();
+            mockAuth.Setup(mock => mock.ParseToken(It.IsAny<HttpRequest>()))
+                .Returns<Claims>(null)
+                .Verifiable();
+            AuthenticationDefinition.AuthenticationInstance = mockAuth.Object;
+
+            var request = CreateHttpRequest(RequestMethod.GET);
+            var logger = (new LoggerFactory()).CreateLogger("Testing");
+
+            // ACT
+            var response = (ObjectResult)GetBuildingList.Run(request, logger);
+
+            // ASSERT
+            Assert.DoesNotThrow(() => mockAuth.Verify(mock => mock.ParseToken(It.IsAny<HttpRequest>()), Times.Once));
+            Assert.DoesNotThrow(() => mockDb.Verify(mock => mock.GetAllBuildings(), Times.Never));
+
+            Assert.IsNotNull(response);
+            Assert.That(response, Is.TypeOf(typeof(ObjectResult)));
+            Assert.That(((ObjectResult)response).StatusCode, Is.EqualTo((int)HttpStatusCode.Unauthorized));
+            var retVal = ((ObjectResult)response).Value;
+
+            Assert.That(retVal, Is.EqualTo("Invalid credentials."));
         }
     }
 }

--- a/BEIMA.Backend.Test/BuildingFunctions/GetBuildingTest.cs
+++ b/BEIMA.Backend.Test/BuildingFunctions/GetBuildingTest.cs
@@ -1,5 +1,8 @@
-﻿using BEIMA.Backend.BuildingFunctions;
+﻿using BEIMA.Backend.AuthService;
+using BEIMA.Backend.BuildingFunctions;
+using BEIMA.Backend.Models;
 using BEIMA.Backend.MongoService;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using MongoDB.Bson;
@@ -29,6 +32,13 @@ namespace BEIMA.Backend.Test.BuildingFunctions
                   .Verifiable();
             MongoDefinition.MongoInstance = mockDb.Object;
 
+            // Setup mock authentication service.
+            Mock<IAuthenticationService> mockAuth = new Mock<IAuthenticationService>();
+            mockAuth.Setup(mock => mock.ParseToken(It.IsAny<HttpRequest>()))
+                .Returns(new Claims { Role = Constants.ADMIN_ROLE, Username = "Bob" })
+                .Verifiable();
+            AuthenticationDefinition.AuthenticationInstance = mockAuth.Object;
+
             // Set up the http request.
             var request = CreateHttpRequest(RequestMethod.GET);
             var logger = (new LoggerFactory()).CreateLogger("Testing");
@@ -37,6 +47,7 @@ namespace BEIMA.Backend.Test.BuildingFunctions
             var response = GetBuilding.Run(request, testId, logger);
 
             // ASSERT
+            Assert.DoesNotThrow(() => mockAuth.Verify(mock => mock.ParseToken(It.IsAny<HttpRequest>()), Times.Once));
             Assert.DoesNotThrow(() => mockDb.Verify(mock => mock.GetBuilding(It.IsAny<ObjectId>()), Times.Once));
 
             Assert.That(response, Is.TypeOf(typeof(NotFoundObjectResult)));
@@ -57,6 +68,13 @@ namespace BEIMA.Backend.Test.BuildingFunctions
                   .Verifiable();
             MongoDefinition.MongoInstance = mockDb.Object;
 
+            // Setup mock authentication service.
+            Mock<IAuthenticationService> mockAuth = new Mock<IAuthenticationService>();
+            mockAuth.Setup(mock => mock.ParseToken(It.IsAny<HttpRequest>()))
+                .Returns(new Claims { Role = Constants.ADMIN_ROLE, Username = "Bob" })
+                .Verifiable();
+            AuthenticationDefinition.AuthenticationInstance = mockAuth.Object;
+
             var request = CreateHttpRequest(RequestMethod.GET);
             var logger = (new LoggerFactory()).CreateLogger("Testing");
 
@@ -64,6 +82,7 @@ namespace BEIMA.Backend.Test.BuildingFunctions
             var response = GetBuilding.Run(request, id, logger);
 
             // ASSERT
+            Assert.DoesNotThrow(() => mockAuth.Verify(mock => mock.ParseToken(It.IsAny<HttpRequest>()), Times.Once));
             Assert.DoesNotThrow(() => mockDb.Verify(mock => mock.GetBuilding(It.IsAny<ObjectId>()), Times.Never));
 
             Assert.That(response, Is.TypeOf(typeof(BadRequestObjectResult)));
@@ -92,6 +111,13 @@ namespace BEIMA.Backend.Test.BuildingFunctions
                   .Verifiable();
             MongoDefinition.MongoInstance = mockDb.Object;
 
+            // Setup mock authentication service.
+            Mock<IAuthenticationService> mockAuth = new Mock<IAuthenticationService>();
+            mockAuth.Setup(mock => mock.ParseToken(It.IsAny<HttpRequest>()))
+                .Returns(new Claims { Role = Constants.ADMIN_ROLE, Username = "Bob" })
+                .Verifiable();
+            AuthenticationDefinition.AuthenticationInstance = mockAuth.Object;
+
             var request = CreateHttpRequest(RequestMethod.GET);
             var logger = (new LoggerFactory()).CreateLogger("Testing");
 
@@ -99,6 +125,7 @@ namespace BEIMA.Backend.Test.BuildingFunctions
             var response = GetBuilding.Run(request, testId, logger);
 
             // ASSERT
+            Assert.DoesNotThrow(() => mockAuth.Verify(mock => mock.ParseToken(It.IsAny<HttpRequest>()), Times.Once));
             Assert.DoesNotThrow(() => mockDb.Verify(mock => mock.GetBuilding(It.IsAny<ObjectId>()), Times.Once));
 
             Assert.That(response, Is.TypeOf(typeof(OkObjectResult)));

--- a/BEIMA.Backend.Test/BuildingFunctions/UpdateBuildingTest.cs
+++ b/BEIMA.Backend.Test/BuildingFunctions/UpdateBuildingTest.cs
@@ -1,5 +1,8 @@
-﻿using BEIMA.Backend.BuildingFunctions;
+﻿using BEIMA.Backend.AuthService;
+using BEIMA.Backend.BuildingFunctions;
+using BEIMA.Backend.Models;
 using BEIMA.Backend.MongoService;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using MongoDB.Bson;
@@ -26,6 +29,13 @@ namespace BEIMA.Backend.Test.BuildingFunctions
                   .Verifiable();
             MongoDefinition.MongoInstance = mockDb.Object;
 
+            // Setup mock authentication service.
+            Mock<IAuthenticationService> mockAuth = new Mock<IAuthenticationService>();
+            mockAuth.Setup(mock => mock.ParseToken(It.IsAny<HttpRequest>()))
+                .Returns(new Claims { Role = Constants.ADMIN_ROLE, Username = "Bob" })
+                .Verifiable();
+            AuthenticationDefinition.AuthenticationInstance = mockAuth.Object;
+
             var request = CreateHttpRequest(RequestMethod.POST, body: TestData._testUpdateBuilding);
             var logger = (new LoggerFactory()).CreateLogger("Testing");
 
@@ -33,6 +43,7 @@ namespace BEIMA.Backend.Test.BuildingFunctions
             var response = await UpdateBuilding.Run(request, testId, logger);
 
             // ASSERT
+            Assert.DoesNotThrow(() => mockAuth.Verify(mock => mock.ParseToken(It.IsAny<HttpRequest>()), Times.Once));
             Assert.DoesNotThrow(() => mockDb.Verify(mock => mock.UpdateBuilding(It.IsAny<BsonDocument>()), Times.Once));
 
             Assert.That(response, Is.TypeOf(typeof(NotFoundObjectResult)));
@@ -53,6 +64,13 @@ namespace BEIMA.Backend.Test.BuildingFunctions
                   .Verifiable();
             MongoDefinition.MongoInstance = mockDb.Object;
 
+            // Setup mock authentication service.
+            Mock<IAuthenticationService> mockAuth = new Mock<IAuthenticationService>();
+            mockAuth.Setup(mock => mock.ParseToken(It.IsAny<HttpRequest>()))
+                .Returns(new Claims { Role = Constants.ADMIN_ROLE, Username = "Bob" })
+                .Verifiable();
+            AuthenticationDefinition.AuthenticationInstance = mockAuth.Object;
+
             var request = CreateHttpRequest(RequestMethod.POST, body: TestData._testUpdateBuilding);
             var logger = (new LoggerFactory()).CreateLogger("Testing");
 
@@ -60,6 +78,7 @@ namespace BEIMA.Backend.Test.BuildingFunctions
             var response = await UpdateBuilding.Run(request, id, logger);
 
             // ASSERT
+            Assert.DoesNotThrow(() => mockAuth.Verify(mock => mock.ParseToken(It.IsAny<HttpRequest>()), Times.Once));
             Assert.DoesNotThrow(() => mockDb.Verify(mock => mock.UpdateBuilding(It.IsAny<BsonDocument>()), Times.Never));
 
             Assert.That(response, Is.TypeOf(typeof(BadRequestObjectResult)));
@@ -83,6 +102,13 @@ namespace BEIMA.Backend.Test.BuildingFunctions
                   .Verifiable();
             MongoDefinition.MongoInstance = mockDb.Object;
 
+            // Setup mock authentication service.
+            Mock<IAuthenticationService> mockAuth = new Mock<IAuthenticationService>();
+            mockAuth.Setup(mock => mock.ParseToken(It.IsAny<HttpRequest>()))
+                .Returns(new Claims { Role = Constants.ADMIN_ROLE, Username = "Bob" })
+                .Verifiable();
+            AuthenticationDefinition.AuthenticationInstance = mockAuth.Object;
+
             var body = TestData._testUpdateBuilding;
             var request = CreateHttpRequest(RequestMethod.POST, body: body);
             var logger = (new LoggerFactory()).CreateLogger("Testing");
@@ -91,6 +117,7 @@ namespace BEIMA.Backend.Test.BuildingFunctions
             var response = await UpdateBuilding.Run(request, testId, logger);
 
             // ASSERT
+            Assert.DoesNotThrow(() => mockAuth.Verify(mock => mock.ParseToken(It.IsAny<HttpRequest>()), Times.Once));
             Assert.DoesNotThrow(() => mockDb.Verify(mock => mock.UpdateBuilding(It.IsAny<BsonDocument>()), Times.Once));
 
             Assert.IsNotNull(response);

--- a/BEIMA.Backend/BuildingFunctions/AddBuilding.cs
+++ b/BEIMA.Backend/BuildingFunctions/AddBuilding.cs
@@ -11,6 +11,7 @@ using BEIMA.Backend.MongoService;
 using MongoDB.Bson;
 using BEIMA.Backend.Models;
 using System.Net;
+using BEIMA.Backend.AuthService;
 
 namespace BEIMA.Backend.BuildingFunctions
 {
@@ -32,6 +33,14 @@ namespace BEIMA.Backend.BuildingFunctions
         {
             log.LogInformation("C# HTTP trigger function processed a building post request.");
 
+            var authService = AuthenticationDefinition.AuthenticationInstance;
+            var claims = authService.ParseToken(req);
+
+            if (claims == null)
+            {
+                return new ObjectResult(Resources.UnauthorizedMessage) { StatusCode = 401 };
+            }
+
             Building building;
             try
             {
@@ -48,7 +57,7 @@ namespace BEIMA.Backend.BuildingFunctions
                 return new BadRequestObjectResult(Resources.CouldNotParseBody);
             }
             // TODO: Use actual user.
-            building.SetLastModified(DateTime.UtcNow, "Anonymous");
+            building.SetLastModified(DateTime.UtcNow, claims.Username);
 
             string message;
             HttpStatusCode statusCode;

--- a/BEIMA.Backend/BuildingFunctions/DeleteBuilding.cs
+++ b/BEIMA.Backend/BuildingFunctions/DeleteBuilding.cs
@@ -1,3 +1,4 @@
+using BEIMA.Backend.AuthService;
 using BEIMA.Backend.MongoService;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -28,6 +29,14 @@ namespace BEIMA.Backend.BuildingFunctions
             ILogger log)
         {
             log.LogInformation("C# HTTP trigger function processed a building delete request.");
+
+            var authService = AuthenticationDefinition.AuthenticationInstance;
+            var claims = authService.ParseToken(req);
+
+            if (claims == null)
+            {
+                return new ObjectResult(Resources.UnauthorizedMessage) { StatusCode = 401 };
+            }
 
             if (!ObjectId.TryParse(id, out _))
             {

--- a/BEIMA.Backend/BuildingFunctions/GetBuilding.cs
+++ b/BEIMA.Backend/BuildingFunctions/GetBuilding.cs
@@ -1,3 +1,4 @@
+using BEIMA.Backend.AuthService;
 using BEIMA.Backend.MongoService;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -28,6 +29,14 @@ namespace BEIMA.Backend.BuildingFunctions
             ILogger log)
         {
             log.LogInformation("C# HTTP trigger function processed a building GET request.");
+
+            var authService = AuthenticationDefinition.AuthenticationInstance;
+            var claims = authService.ParseToken(req);
+
+            if (claims == null)
+            {
+                return new ObjectResult(Resources.UnauthorizedMessage) { StatusCode = 401 };
+            }
 
             // Check if the id is valid.
             if (string.IsNullOrEmpty(id) || !ObjectId.TryParse(id, out _))

--- a/BEIMA.Backend/BuildingFunctions/GetBuildingList.cs
+++ b/BEIMA.Backend/BuildingFunctions/GetBuildingList.cs
@@ -1,3 +1,4 @@
+using BEIMA.Backend.AuthService;
 using BEIMA.Backend.MongoService;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -26,6 +27,14 @@ namespace BEIMA.Backend.BuildingFunctions
             ILogger log)
         {
             log.LogInformation("C# HTTP trigger function processed a building list request.");
+
+            var authService = AuthenticationDefinition.AuthenticationInstance;
+            var claims = authService.ParseToken(req);
+
+            if (claims == null)
+            {
+                return new ObjectResult(Resources.UnauthorizedMessage) { StatusCode = 401 };
+            }
 
             var mongo = MongoDefinition.MongoInstance;
             var buildings = mongo.GetAllBuildings();

--- a/BEIMA.Backend/BuildingFunctions/UpdateBuilding.cs
+++ b/BEIMA.Backend/BuildingFunctions/UpdateBuilding.cs
@@ -12,6 +12,7 @@ using BEIMA.Backend.MongoService;
 using MongoDB.Bson.Serialization;
 using BEIMA.Backend.Models;
 using System.Net;
+using BEIMA.Backend.AuthService;
 
 namespace BEIMA.Backend.BuildingFunctions
 {
@@ -34,6 +35,14 @@ namespace BEIMA.Backend.BuildingFunctions
             ILogger log)
         {
             log.LogInformation("C# HTTP trigger function processed a building update request.");
+
+            var authService = AuthenticationDefinition.AuthenticationInstance;
+            var claims = authService.ParseToken(req);
+
+            if (claims == null)
+            {
+                return new ObjectResult(Resources.UnauthorizedMessage) { StatusCode = 401 };
+            }
 
             if (!ObjectId.TryParse(id, out _))
             {
@@ -59,7 +68,7 @@ namespace BEIMA.Backend.BuildingFunctions
                 return new BadRequestObjectResult(Resources.CouldNotParseBody);
             }
 
-            building.SetLastModified(DateTime.UtcNow, "Anonymous");
+            building.SetLastModified(DateTime.UtcNow, claims.Username);
 
             string message;
             HttpStatusCode statusCode;


### PR DESCRIPTION
<!--
These comments inside these brackets will not appear in the pull request.

The pull request should be linked to either:
 - a task (i.e., use 'Closes #TaskID' or 'Resolves #TaskID')
 - a bug (i.e., use 'Closes #BugID' or 'Fixes #BugID')

For more details, see: https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes #407 

Adds authentication to the front of all the building functions as well as updates the last modified user to use the username in the claims token for the add and update building endpoint.
