### PR TITLE
Device type endpoint authentication

### DIFF
--- a/BEIMA.Backend.FT/DeviceTypeFT.cs
+++ b/BEIMA.Backend.FT/DeviceTypeFT.cs
@@ -244,7 +244,7 @@ namespace BEIMA.Backend.FT
 
                 Assert.That(deviceType.LastModified, Is.Not.Null);
                 Assert.That(deviceType.LastModified?.Date, Is.Not.Null);
-                Assert.That(deviceType.LastModified?.User, Is.EqualTo("Anonymous"));
+                Assert.That(deviceType.LastModified?.User, Is.EqualTo(TestUsername));
             }
         }
 

--- a/BEIMA.Backend.FT/DeviceTypeFT.cs
+++ b/BEIMA.Backend.FT/DeviceTypeFT.cs
@@ -12,6 +12,8 @@ namespace BEIMA.Backend.FT
     [TestFixture]
     public class DeviceTypeFT : FunctionalTestBase
     {
+        #region SetUp and Teardown
+
         [SetUp]
         public async Task SetUp()
         {
@@ -36,6 +38,10 @@ namespace BEIMA.Backend.FT
             }
         }
 
+        #endregion SetUp and Teardown
+
+        #region Device Type GET Tests
+
         [TestCase("xxx")]
         [TestCase("1234")]
         [TestCase("1234567890abcdef1234567x")]
@@ -58,6 +64,28 @@ namespace BEIMA.Backend.FT
             Assert.IsNotNull(ex);
             Assert.That(ex?.StatusCode, Is.EqualTo(HttpStatusCode.NotFound));
         }
+
+        [TestCase("xxx")]
+        [TestCase("1234")]
+        [TestCase("1234567890abcdef1234567x")]
+        [TestCase("1234567890abcdef12345678")]
+        public void InvalidCredentials_DeviceTypeGet_ReturnsUnauthenticated(string id)
+        {
+            // ARRANGE
+            // ACT
+            var ex = Assert.ThrowsAsync<BeimaException>(async () =>
+                await UnauthorizedTestClient.GetDeviceType(id)
+            );
+
+            // ASSERT
+            Assert.That(ex, Is.Not.Null);
+            Assert.That(ex?.Message, Does.Contain("Invalid credentials."));
+            Assert.That(ex?.StatusCode, Is.EqualTo(HttpStatusCode.Unauthorized));
+        }
+
+        #endregion Device Type GET Tests
+
+        #region Device Type Add Tests
 
         [Test]
         public async Task NoDeviceTypesInDb_AddDeviceType_DeviceTypeAddedSuccessfullyAsync()
@@ -99,6 +127,38 @@ namespace BEIMA.Backend.FT
             Assert.That(getDeviceType.Fields, Contains.Value(device.Fields[1]));
             Assert.That(getDeviceType.Fields, Contains.Value(device.Fields[2]));
         }
+
+        [Test]
+        public void InvalidCredentials_AddDeviceType_ReturnsUnauthorized()
+        {
+            // ARRANGE
+            var device = new DeviceTypeAdd
+            {
+                Description = "This is a boiler type.",
+                Name = "Boiler",
+                Notes = "Some type notes.",
+                Fields = new List<string>()
+                {
+                    "MaxTemperature",
+                    "MinTemperature",
+                    "Capacity"
+                }
+            };
+
+            // ACT
+            var ex = Assert.ThrowsAsync<BeimaException>(async () =>
+                await UnauthorizedTestClient.AddDeviceType(device)
+            );
+
+            // ASSERT
+            Assert.That(ex, Is.Not.Null);
+            Assert.That(ex?.Message, Does.Contain("Invalid credentials."));
+            Assert.That(ex?.StatusCode, Is.EqualTo(HttpStatusCode.Unauthorized));
+        }
+
+        #endregion Device Type Add Tests
+
+        #region Device Type List Tests
 
         [Test]
         public async Task DeviceTypesInDatabase_GetDeviceTypeList_ReturnsDeviceTypeList()
@@ -189,6 +249,70 @@ namespace BEIMA.Backend.FT
         }
 
         [Test]
+        public async Task InvalidCredentials_GetDeviceTypeList_ReturnsUnauthenticated()
+        {
+            // ARRANGE
+            var deviceTypeList = new List<DeviceTypeAdd>
+            {
+                new DeviceTypeAdd
+                {
+                    Description = "Boiler description.",
+                    Name = "Boiler",
+                    Notes = "Some boiler notes.",
+                    Fields = new List<string>
+                    {
+                        "Type",
+                        "Fuel Input Rate",
+                        "Output",
+                    },
+                },
+                new DeviceTypeAdd
+                {
+                    Description = "Meters description",
+                    Name = "Electric Meters",
+                    Notes = "Some meter notes.",
+                    Fields = new List<string>
+                    {
+                        "Account Number",
+                        "Service ID",
+                        "Voltage",
+                    },
+                },
+                new DeviceTypeAdd
+                {
+                    Description = "Cooling tower description",
+                    Name = "Cooling Tower",
+                    Notes = "Some cooling tower notes.",
+                    Fields = new List<string>
+                    {
+                        "Type",
+                        "Chiller(s) Served",
+                        "Capacity",
+                    },
+                },
+            };
+
+            foreach (var deviceType in deviceTypeList)
+            {
+                await TestClient.AddDeviceType(deviceType);
+            }
+
+            // ACT
+            var ex = Assert.ThrowsAsync<BeimaException>(async () =>
+                await UnauthorizedTestClient.GetDeviceTypeList()
+            );
+
+            // ASSERT
+            Assert.That(ex, Is.Not.Null);
+            Assert.That(ex?.Message, Does.Contain("Invalid credentials."));
+            Assert.That(ex?.StatusCode, Is.EqualTo(HttpStatusCode.Unauthorized));
+        }
+
+        #endregion Device Type List Tests
+
+        #region Device Type Delete Tests
+
+        [Test]
         public async Task DeviceTypeInDatabase_DeleteDeviceType_DeviceTypeDeletedSuccessfully()
         {
             // ARRANGE
@@ -215,6 +339,96 @@ namespace BEIMA.Backend.FT
             var ex = Assert.ThrowsAsync<BeimaException>(async () => await TestClient.GetDeviceType(deviceTypeId));
             Assert.That(ex?.StatusCode, Is.EqualTo(HttpStatusCode.NotFound));
         }
+
+        [Test]
+        public async Task DeviceTypeWithDeviceInDatabase_DeleteDeviceType_DeletetionStopped()
+        {
+            // ARRANGE
+            var deviceType = new DeviceTypeAdd
+            {
+                Description = "Boiler description.",
+                Name = "Boiler",
+                Notes = "Some other boiler notes.",
+                Fields = new List<string>
+                    {
+                        "Type",
+                        "Fuel Input Rate",
+                        "Output",
+                    },
+            };
+
+            var deviceTypeId = await TestClient.AddDeviceType(deviceType);
+            var addedDeviceType = await TestClient.GetDeviceType(deviceTypeId);
+
+            var device = new Device()
+            {
+                DeviceTag = "B-34",
+                DeviceTypeId = deviceTypeId,
+                Fields = new Dictionary<string, string> {
+                    { addedDeviceType.Fields?.Keys?.ToList()[0] ?? "Bad Fields", "Tall boiler." },
+                    { addedDeviceType.Fields?.Keys?.ToList()[1] ?? "Bad Fields", "23" },
+                    { addedDeviceType.Fields?.Keys?.ToList()[2] ?? "Bad Fields", "38" },
+                },
+                Location = new DeviceLocation()
+                {
+                    BuildingId = null,
+                    Latitude = "78.6",
+                    Longitude = "43.2",
+                    Notes = "Some notes."
+                },
+                Manufacturer = "Generic Inc.",
+                ModelNum = "1234",
+                Notes = "Some notes.",
+                SerialNum = "4321",
+                YearManufactured = 2001,
+            };
+
+            var deviceId = await TestClient.AddDevice(device);
+            Assume.That(deviceId, Is.Not.Null.And.Not.Empty);
+
+            // ACT
+            var ex = Assert.ThrowsAsync<BeimaException>(async () => await TestClient.DeleteDeviceType(deviceTypeId));
+
+            // ASSERT
+            Assert.That(ex?.StatusCode, Is.EqualTo(HttpStatusCode.Conflict));
+            Assert.That(ex?.Message,
+                        Contains.Substring("The device type could not be deleted because at least one device exists in the database with this device type."));
+        }
+
+        [Test]
+        public async Task InvalidCredentials_DeleteDeviceType_ReturnsUnauthenticated()
+        {
+            // ARRANGE
+            var deviceType = new DeviceTypeAdd
+            {
+                Description = "Boiler description.",
+                Name = "Boiler",
+                Notes = "Some other boiler notes.",
+                Fields = new List<string>
+                    {
+                        "Type",
+                        "Fuel Input Rate",
+                        "Output",
+                    },
+            };
+
+            var deviceTypeId = await TestClient.AddDeviceType(deviceType);
+            Assume.That(await TestClient.GetDeviceType(deviceTypeId), Is.Not.Null);
+
+            // ACT
+            var ex = Assert.ThrowsAsync<BeimaException>(async () =>
+                await UnauthorizedTestClient.DeleteDeviceType(deviceTypeId)
+            );
+
+            // ASSERT
+            Assert.That(ex, Is.Not.Null);
+            Assert.That(ex?.Message, Does.Contain("Invalid credentials."));
+            Assert.That(ex?.StatusCode, Is.EqualTo(HttpStatusCode.Unauthorized));
+        }
+
+        #endregion Device Type Delete Tests
+
+        #region Device Type Update Tests
 
         [Test]
         public async Task DeviceTypeInDatabase_UpdateDeviceType_ReturnsUpdatedDeviceType()
@@ -387,5 +601,64 @@ namespace BEIMA.Backend.FT
                 Assert.That(updatedDeviceType.Fields, Contains.Key(key));
             }
         }
+
+        [Test]
+        public async Task InvalidCredentials_UpdateDeviceType_ReturnsUnauthorized()
+        {
+            // ARRANGE
+            var origDeviceType = new DeviceTypeAdd
+            {
+                Description = "Boiler description.",
+                Name = "Boiler",
+                Notes = "Some boiler notes.",
+                Fields = new List<string>
+                {
+                    "Type",
+                    "Fuel Input Rate",
+                    "Output",
+                },
+            };
+
+            var deviceTypeId = await TestClient.AddDeviceType(origDeviceType);
+            var origItem = await TestClient.GetDeviceType(deviceTypeId);
+
+            var updateDictionary = new Dictionary<string, string>();
+            if (origItem.Fields != null)
+            {
+                foreach (var item in origItem.Fields)
+                {
+                    updateDictionary.Add(item.Key, item.Value);
+                    if (item.Value.Equals("Type"))
+                    {
+                        updateDictionary[item.Key] = "Boiler Type";
+                    }
+                }
+            }
+
+            var updateItem = new DeviceTypeUpdate
+            {
+                Id = origItem.Id,
+                Description = origItem.Description,
+                Name = origItem.Name,
+                Notes = "Some other boiler notes.",
+                Fields = updateDictionary,
+                NewFields = new List<string>
+                {
+                    "Capacity",
+                },
+            };
+
+            // ACT
+            var ex = Assert.ThrowsAsync<BeimaException>(async () =>
+                await UnauthorizedTestClient.UpdateDeviceType(updateItem)
+            );
+
+            // ASSERT
+            Assert.That(ex, Is.Not.Null);
+            Assert.That(ex?.Message, Does.Contain("Invalid credentials."));
+            Assert.That(ex?.StatusCode, Is.EqualTo(HttpStatusCode.Unauthorized));
+        }
+
+        #endregion Device Type Update Tests
     }
 }

--- a/BEIMA.Backend.Test/DeviceTypeFunctions/DeleteDeviceTypeTest.cs
+++ b/BEIMA.Backend.Test/DeviceTypeFunctions/DeleteDeviceTypeTest.cs
@@ -1,8 +1,12 @@
-﻿using BEIMA.Backend.DeviceTypeFunctions;
+﻿using BEIMA.Backend.AuthService;
+using BEIMA.Backend.DeviceTypeFunctions;
+using BEIMA.Backend.Models;
 using BEIMA.Backend.MongoService;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using MongoDB.Bson;
+using MongoDB.Driver;
 using Moq;
 using NUnit.Framework;
 using System.Collections.Generic;
@@ -23,6 +27,12 @@ namespace BEIMA.Backend.Test.DeviceTypeFunctions
             Mock<IMongoConnector> mockDb = new Mock<IMongoConnector>();
             MongoDefinition.MongoInstance = mockDb.Object;
 
+            Mock<IAuthenticationService> mockAuth = new Mock<IAuthenticationService>();
+            mockAuth.Setup(mock => mock.ParseToken(It.IsAny<HttpRequest>()))
+                .Returns(new Claims { Role = Constants.ADMIN_ROLE, Username = "Bob" })
+                .Verifiable();
+            AuthenticationDefinition.AuthenticationInstance = mockAuth.Object;
+
             var request = CreateHttpRequest(RequestMethod.POST);
             var logger = (new LoggerFactory()).CreateLogger("Testing");
 
@@ -30,7 +40,8 @@ namespace BEIMA.Backend.Test.DeviceTypeFunctions
             var response = DeleteDeviceType.Run(request, id, logger);
 
             // ASSERT
-            Assert.DoesNotThrow(() => mockDb.Verify(mock => mock.GetAllDevices(), Times.Never));
+            Assert.DoesNotThrow(() => mockAuth.Verify(mock => mock.ParseToken(It.IsAny<HttpRequest>()), Times.Once));
+            Assert.DoesNotThrow(() => mockDb.Verify(mock => mock.GetFilteredDevices(It.IsAny<FilterDefinition<BsonDocument>>()), Times.Never));
             Assert.DoesNotThrow(() => mockDb.Verify(mock => mock.DeleteDeviceType(It.IsAny<ObjectId>()), Times.Never));
 
             Assert.That(response, Is.TypeOf(typeof(BadRequestObjectResult)));
@@ -44,13 +55,19 @@ namespace BEIMA.Backend.Test.DeviceTypeFunctions
             var testId = ObjectId.GenerateNewId().ToString();
 
             Mock<IMongoConnector> mockDb = new Mock<IMongoConnector>();
-            mockDb.Setup(mock => mock.GetAllDevices())
+            mockDb.Setup(mock => mock.GetFilteredDevices(It.IsAny<FilterDefinition<BsonDocument>>()))
                   .Returns(new List<BsonDocument>())
                   .Verifiable();
             mockDb.Setup(mock => mock.DeleteDeviceType(It.Is<ObjectId>(oid => oid == new ObjectId(testId))))
                   .Returns(false)
                   .Verifiable();
             MongoDefinition.MongoInstance = mockDb.Object;
+
+            Mock<IAuthenticationService> mockAuth = new Mock<IAuthenticationService>();
+            mockAuth.Setup(mock => mock.ParseToken(It.IsAny<HttpRequest>()))
+                .Returns(new Claims { Role = Constants.ADMIN_ROLE, Username = "Bob" })
+                .Verifiable();
+            AuthenticationDefinition.AuthenticationInstance = mockAuth.Object;
 
             var request = CreateHttpRequest(RequestMethod.POST);
             var logger = (new LoggerFactory()).CreateLogger("Testing");
@@ -59,7 +76,8 @@ namespace BEIMA.Backend.Test.DeviceTypeFunctions
             var response = DeleteDeviceType.Run(request, testId, logger);
 
             // ASSERT
-            Assert.DoesNotThrow(() => mockDb.Verify(mock => mock.GetAllDevices(), Times.Once));
+            Assert.DoesNotThrow(() => mockAuth.Verify(mock => mock.ParseToken(It.IsAny<HttpRequest>()), Times.Once));
+            Assert.DoesNotThrow(() => mockDb.Verify(mock => mock.GetFilteredDevices(It.IsAny<FilterDefinition<BsonDocument>>()), Times.Once));
             Assert.DoesNotThrow(() => mockDb.Verify(mock => mock.DeleteDeviceType(It.IsAny<ObjectId>()), Times.Once));
 
             Assert.That(response, Is.TypeOf(typeof(NotFoundObjectResult)));
@@ -76,13 +94,19 @@ namespace BEIMA.Backend.Test.DeviceTypeFunctions
             device.DeviceTypeId = new ObjectId(testId);
 
             Mock<IMongoConnector> mockDb = new Mock<IMongoConnector>();
-            mockDb.Setup(mock => mock.GetAllDevices())
+            mockDb.Setup(mock => mock.GetFilteredDevices(It.IsAny<FilterDefinition<BsonDocument>>()))
                   .Returns(new List<BsonDocument> { device.ToBsonDocument() })
                   .Verifiable();
             mockDb.Setup(mock => mock.DeleteDeviceType(It.Is<ObjectId>(oid => oid == new ObjectId(testId))))
                   .Returns(true)
                   .Verifiable();
             MongoDefinition.MongoInstance = mockDb.Object;
+
+            Mock<IAuthenticationService> mockAuth = new Mock<IAuthenticationService>();
+            mockAuth.Setup(mock => mock.ParseToken(It.IsAny<HttpRequest>()))
+                .Returns(new Claims { Role = Constants.ADMIN_ROLE, Username = "Bob" })
+                .Verifiable();
+            AuthenticationDefinition.AuthenticationInstance = mockAuth.Object;
 
             var request = CreateHttpRequest(RequestMethod.GET);
             var logger = (new LoggerFactory()).CreateLogger("Testing");
@@ -91,7 +115,8 @@ namespace BEIMA.Backend.Test.DeviceTypeFunctions
             var response = DeleteDeviceType.Run(request, testId, logger);
 
             // ASSERT
-            Assert.DoesNotThrow(() => mockDb.Verify(mock => mock.GetAllDevices(), Times.Once));
+            Assert.DoesNotThrow(() => mockAuth.Verify(mock => mock.ParseToken(It.IsAny<HttpRequest>()), Times.Once));
+            Assert.DoesNotThrow(() => mockDb.Verify(mock => mock.GetFilteredDevices(It.IsAny<FilterDefinition<BsonDocument>>()), Times.Once));
             Assert.DoesNotThrow(() => mockDb.Verify(mock => mock.DeleteDeviceType(It.IsAny<ObjectId>()), Times.Never));
 
             Assert.That(response, Is.TypeOf(typeof(ConflictObjectResult)));
@@ -105,13 +130,19 @@ namespace BEIMA.Backend.Test.DeviceTypeFunctions
             var testId = "1234567890abcdef12345678";
 
             Mock<IMongoConnector> mockDb = new Mock<IMongoConnector>();
-            mockDb.Setup(mock => mock.GetAllDevices())
+            mockDb.Setup(mock => mock.GetFilteredDevices(It.IsAny<FilterDefinition<BsonDocument>>()))
                   .Returns(new List<BsonDocument>())
                   .Verifiable();
             mockDb.Setup(mock => mock.DeleteDeviceType(It.Is<ObjectId>(oid => oid == new ObjectId(testId))))
                   .Returns(true)
                   .Verifiable();
             MongoDefinition.MongoInstance = mockDb.Object;
+
+            Mock<IAuthenticationService> mockAuth = new Mock<IAuthenticationService>();
+            mockAuth.Setup(mock => mock.ParseToken(It.IsAny<HttpRequest>()))
+                .Returns(new Claims { Role = Constants.ADMIN_ROLE, Username = "Bob" })
+                .Verifiable();
+            AuthenticationDefinition.AuthenticationInstance = mockAuth.Object;
 
             var request = CreateHttpRequest(RequestMethod.GET);
             var logger = (new LoggerFactory()).CreateLogger("Testing");
@@ -120,11 +151,43 @@ namespace BEIMA.Backend.Test.DeviceTypeFunctions
             var response = DeleteDeviceType.Run(request, testId, logger);
 
             // ASSERT
-            Assert.DoesNotThrow(() => mockDb.Verify(mock => mock.GetAllDevices(), Times.Once));
+            Assert.DoesNotThrow(() => mockAuth.Verify(mock => mock.ParseToken(It.IsAny<HttpRequest>()), Times.Once));
+            Assert.DoesNotThrow(() => mockDb.Verify(mock => mock.GetFilteredDevices(It.IsAny<FilterDefinition<BsonDocument>>()), Times.Once));
             Assert.DoesNotThrow(() => mockDb.Verify(mock => mock.DeleteDeviceType(It.IsAny<ObjectId>()), Times.Once));
 
             Assert.That(response, Is.TypeOf(typeof(OkResult)));
             Assert.That(((OkResult)response).StatusCode, Is.EqualTo((int)HttpStatusCode.OK));
+        }
+
+        [Test]
+        public void InvalidCredentials_DeleteDeviceType_ReturnsUnauthenticated()
+        {
+            // ARRANGE
+            var testId = "1234567890abcdef12345678";
+
+            Mock<IMongoConnector> mockDb = new Mock<IMongoConnector>();
+            MongoDefinition.MongoInstance = mockDb.Object;
+
+            Mock<IAuthenticationService> mockAuth = new Mock<IAuthenticationService>();
+            mockAuth.Setup(mock => mock.ParseToken(It.IsAny<HttpRequest>()))
+                .Returns<Claims>(null)
+                .Verifiable();
+            AuthenticationDefinition.AuthenticationInstance = mockAuth.Object;
+
+            var request = CreateHttpRequest(RequestMethod.GET);
+            var logger = (new LoggerFactory()).CreateLogger("Testing");
+
+            // ACT
+            var response = (ObjectResult)DeleteDeviceType.Run(request, testId, logger);
+
+            // ASSERT
+            Assert.DoesNotThrow(() => mockAuth.Verify(mock => mock.ParseToken(It.IsAny<HttpRequest>()), Times.Once));
+            Assert.DoesNotThrow(() => mockDb.Verify(mock => mock.GetFilteredDevices(It.IsAny<FilterDefinition<BsonDocument>>()), Times.Never));
+            Assert.DoesNotThrow(() => mockDb.Verify(mock => mock.DeleteDeviceType(It.IsAny<ObjectId>()), Times.Never));
+
+            Assert.That(response, Is.Not.Null);
+            Assert.That(response.StatusCode, Is.EqualTo((int)HttpStatusCode.Unauthorized));
+            Assert.That(response.Value, Is.EqualTo("Invalid credentials."));
         }
     }
 }

--- a/BEIMA.Backend.Test/DeviceTypeFunctions/UpdateDeviceTypeTest.cs
+++ b/BEIMA.Backend.Test/DeviceTypeFunctions/UpdateDeviceTypeTest.cs
@@ -1,8 +1,12 @@
-﻿using BEIMA.Backend.DeviceTypeFunctions;
+﻿using BEIMA.Backend.AuthService;
+using BEIMA.Backend.DeviceTypeFunctions;
+using BEIMA.Backend.Models;
 using BEIMA.Backend.MongoService;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using MongoDB.Bson;
+using MongoDB.Driver;
 using Moq;
 using NUnit.Framework;
 using System;
@@ -30,6 +34,12 @@ namespace BEIMA.Backend.Test.DeviceTypeFunctions
                   .Verifiable();
             MongoDefinition.MongoInstance = mockDb.Object;
 
+            Mock<IAuthenticationService> mockAuth = new Mock<IAuthenticationService>();
+            mockAuth.Setup(mock => mock.ParseToken(It.IsAny<HttpRequest>()))
+                .Returns(new Claims { Role = Constants.ADMIN_ROLE, Username = "Bob" })
+                .Verifiable();
+            AuthenticationDefinition.AuthenticationInstance = mockAuth.Object;
+
             var request = CreateHttpRequest(RequestMethod.POST, body: TestData._testUpdateDeviceType);
             var logger = (new LoggerFactory()).CreateLogger("Testing");
 
@@ -37,8 +47,9 @@ namespace BEIMA.Backend.Test.DeviceTypeFunctions
             var response = await UpdateDeviceType.Run(request, testId, logger);
 
             // ASSERT
+            Assert.DoesNotThrow(() => mockAuth.Verify(mock => mock.ParseToken(It.IsAny<HttpRequest>()), Times.Once));
             Assert.DoesNotThrow(() => mockDb.Verify(mock => mock.GetDeviceType(It.IsAny<ObjectId>()), Times.Once));
-            Assert.DoesNotThrow(() => mockDb.Verify(mock => mock.GetAllDevices(), Times.Never));
+            Assert.DoesNotThrow(() => mockDb.Verify(mock => mock.GetFilteredDevices(It.IsAny<FilterDefinition<BsonDocument>>()), Times.Never));
             Assert.DoesNotThrow(() => mockDb.Verify(mock => mock.UpdateDeviceType(It.IsAny<BsonDocument>()), Times.Never));
             Assert.DoesNotThrow(() => mockDb.Verify(mock => mock.UpdateDevice(It.IsAny<BsonDocument>()), Times.Never));
 
@@ -63,6 +74,12 @@ namespace BEIMA.Backend.Test.DeviceTypeFunctions
                   .Verifiable();
             MongoDefinition.MongoInstance = mockDb.Object;
 
+            Mock<IAuthenticationService> mockAuth = new Mock<IAuthenticationService>();
+            mockAuth.Setup(mock => mock.ParseToken(It.IsAny<HttpRequest>()))
+                .Returns(new Claims { Role = Constants.ADMIN_ROLE, Username = "Bob" })
+                .Verifiable();
+            AuthenticationDefinition.AuthenticationInstance = mockAuth.Object;
+
             var request = CreateHttpRequest(RequestMethod.POST, body: TestData._testUpdateDeviceType);
             var logger = (new LoggerFactory()).CreateLogger("Testing");
 
@@ -70,8 +87,9 @@ namespace BEIMA.Backend.Test.DeviceTypeFunctions
             var response = await UpdateDeviceType.Run(request, id, logger);
 
             // ASSERT
+            Assert.DoesNotThrow(() => mockAuth.Verify(mock => mock.ParseToken(It.IsAny<HttpRequest>()), Times.Once));
             Assert.DoesNotThrow(() => mockDb.Verify(mock => mock.GetDeviceType(It.IsAny<ObjectId>()), Times.Never));
-            Assert.DoesNotThrow(() => mockDb.Verify(mock => mock.GetAllDevices(), Times.Never));
+            Assert.DoesNotThrow(() => mockDb.Verify(mock => mock.GetFilteredDevices(It.IsAny<FilterDefinition<BsonDocument>>()), Times.Never));
             Assert.DoesNotThrow(() => mockDb.Verify(mock => mock.UpdateDeviceType(It.IsAny<BsonDocument>()), Times.Never));
             Assert.DoesNotThrow(() => mockDb.Verify(mock => mock.UpdateDevice(It.IsAny<BsonDocument>()), Times.Never));
 
@@ -102,13 +120,19 @@ namespace BEIMA.Backend.Test.DeviceTypeFunctions
             mockDb.Setup(mock => mock.GetDeviceType(It.Is<ObjectId>(oid => oid.ToString().Equals(testId))))
                   .Returns(origDeviceType.GetBsonDocument())
                   .Verifiable();
-            mockDb.Setup(mock => mock.GetAllDevices())
+            mockDb.Setup(mock => mock.GetFilteredDevices(It.IsAny<FilterDefinition<BsonDocument>>()))
                   .Returns(new List<BsonDocument>())
                   .Verifiable();
             mockDb.Setup(mock => mock.UpdateDeviceType(It.IsAny<BsonDocument>()))
                   .Returns(deviceType.GetBsonDocument())
                   .Verifiable();
             MongoDefinition.MongoInstance = mockDb.Object;
+
+            Mock<IAuthenticationService> mockAuth = new Mock<IAuthenticationService>();
+            mockAuth.Setup(mock => mock.ParseToken(It.IsAny<HttpRequest>()))
+                .Returns(new Claims { Role = Constants.ADMIN_ROLE, Username = "Bob" })
+                .Verifiable();
+            AuthenticationDefinition.AuthenticationInstance = mockAuth.Object;
 
             var body = TestData._testUpdateDeviceType;
             var request = CreateHttpRequest(RequestMethod.POST, body: body);
@@ -118,8 +142,9 @@ namespace BEIMA.Backend.Test.DeviceTypeFunctions
             var response = await UpdateDeviceType.Run(request, testId, logger);
 
             // ASSERT
+            Assert.DoesNotThrow(() => mockAuth.Verify(mock => mock.ParseToken(It.IsAny<HttpRequest>()), Times.Once));
             Assert.DoesNotThrow(() => mockDb.Verify(mock => mock.GetDeviceType(It.IsAny<ObjectId>()), Times.Once));
-            Assert.DoesNotThrow(() => mockDb.Verify(mock => mock.GetAllDevices(), Times.Once));
+            Assert.DoesNotThrow(() => mockDb.Verify(mock => mock.GetFilteredDevices(It.IsAny<FilterDefinition<BsonDocument>>()), Times.Once));
             Assert.DoesNotThrow(() => mockDb.Verify(mock => mock.UpdateDeviceType(It.IsAny<BsonDocument>()), Times.Once));
             Assert.DoesNotThrow(() => mockDb.Verify(mock => mock.UpdateDevice(It.IsAny<BsonDocument>()), Times.Never));
 
@@ -177,7 +202,7 @@ namespace BEIMA.Backend.Test.DeviceTypeFunctions
             mockDb.Setup(mock => mock.GetDeviceType(It.Is<ObjectId>(oid => oid.ToString().Equals(testId))))
                   .Returns(origDeviceType.GetBsonDocument())
                   .Verifiable();
-            mockDb.Setup(mock => mock.GetAllDevices())
+            mockDb.Setup(mock => mock.GetFilteredDevices(It.IsAny<FilterDefinition<BsonDocument>>()))
                   .Returns(new List<BsonDocument> { origDevice.GetBsonDocument() })
                   .Verifiable();
             mockDb.Setup(mock => mock.UpdateDeviceType(It.IsAny<BsonDocument>()))
@@ -188,6 +213,12 @@ namespace BEIMA.Backend.Test.DeviceTypeFunctions
                   .Verifiable();
             MongoDefinition.MongoInstance = mockDb.Object;
 
+            Mock<IAuthenticationService> mockAuth = new Mock<IAuthenticationService>();
+            mockAuth.Setup(mock => mock.ParseToken(It.IsAny<HttpRequest>()))
+                .Returns(new Claims { Role = Constants.ADMIN_ROLE, Username = "Bob" })
+                .Verifiable();
+            AuthenticationDefinition.AuthenticationInstance = mockAuth.Object;
+
             var body = TestData._testUpdateDeviceType;
             var request = CreateHttpRequest(RequestMethod.POST, body: body);
             var logger = (new LoggerFactory()).CreateLogger("Testing");
@@ -196,8 +227,9 @@ namespace BEIMA.Backend.Test.DeviceTypeFunctions
             var response = await UpdateDeviceType.Run(request, testId, logger);
 
             // ASSERT
+            Assert.DoesNotThrow(() => mockAuth.Verify(mock => mock.ParseToken(It.IsAny<HttpRequest>()), Times.Once));
             Assert.DoesNotThrow(() => mockDb.Verify(mock => mock.GetDeviceType(It.IsAny<ObjectId>()), Times.Once));
-            Assert.DoesNotThrow(() => mockDb.Verify(mock => mock.GetAllDevices(), Times.Once));
+            Assert.DoesNotThrow(() => mockDb.Verify(mock => mock.GetFilteredDevices(It.IsAny<FilterDefinition<BsonDocument>>()), Times.Once));
             Assert.DoesNotThrow(() => mockDb.Verify(mock => mock.UpdateDeviceType(It.IsAny<BsonDocument>()), Times.Once));
             Assert.DoesNotThrow(() => mockDb.Verify(mock => mock.UpdateDevice(It.IsAny<BsonDocument>()), Times.Once));
 

--- a/BEIMA.Backend/DeviceTypeFunctions/AddDeviceType.cs
+++ b/BEIMA.Backend/DeviceTypeFunctions/AddDeviceType.cs
@@ -12,6 +12,7 @@ using MongoDB.Bson;
 using System.Collections.Generic;
 using System.Net;
 using Newtonsoft.Json.Linq;
+using BEIMA.Backend.AuthService;
 
 namespace BEIMA.Backend.DeviceTypeFunctions
 {
@@ -32,6 +33,14 @@ namespace BEIMA.Backend.DeviceTypeFunctions
             ILogger log)
         {
             log.LogInformation("C# HTTP trigger function processed a device type POST request.");
+
+            var authService = AuthenticationDefinition.AuthenticationInstance;
+            var claims = authService.ParseToken(req);
+
+            if (claims == null)
+            {
+                return new ObjectResult(Resources.UnauthorizedMessage) { StatusCode = StatusCodes.Status401Unauthorized };
+            }
 
             DeviceType deviceType;
             try
@@ -54,8 +63,8 @@ namespace BEIMA.Backend.DeviceTypeFunctions
             {
                 return new BadRequestObjectResult(Resources.CouldNotParseBody);
             }
-            // TODO: Use actual user.
-            deviceType.SetLastModified(DateTime.UtcNow, "Anonymous");
+
+            deviceType.SetLastModified(DateTime.UtcNow, claims.Username);
 
             string message;
             HttpStatusCode statusCode;

--- a/BEIMA.Backend/DeviceTypeFunctions/GetDeviceType.cs
+++ b/BEIMA.Backend/DeviceTypeFunctions/GetDeviceType.cs
@@ -1,3 +1,4 @@
+using BEIMA.Backend.AuthService;
 using BEIMA.Backend.MongoService;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -27,6 +28,14 @@ namespace BEIMA.Backend.DeviceTypeFunctions
             ILogger log)
         {
             log.LogInformation("C# HTTP trigger function processed a device type get request.");
+
+            var authService = AuthenticationDefinition.AuthenticationInstance;
+            var claims = authService.ParseToken(req);
+
+            if (claims == null)
+            {
+                return new ObjectResult(Resources.UnauthorizedMessage) { StatusCode = StatusCodes.Status401Unauthorized };
+            }
 
             // Check if the id is valid.
             if (string.IsNullOrEmpty(id) || !ObjectId.TryParse(id, out _))

--- a/BEIMA.Backend/DeviceTypeFunctions/GetDeviceTypeList.cs
+++ b/BEIMA.Backend/DeviceTypeFunctions/GetDeviceTypeList.cs
@@ -1,3 +1,4 @@
+using BEIMA.Backend.AuthService;
 using BEIMA.Backend.MongoService;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -26,6 +27,14 @@ namespace BEIMA.Backend.DeviceTypeFunctions
             ILogger log)
         {
             log.LogInformation("C# HTTP trigger function processed a device type get list request.");
+
+            var authService = AuthenticationDefinition.AuthenticationInstance;
+            var claims = authService.ParseToken(req);
+
+            if (claims == null)
+            {
+                return new ObjectResult(Resources.UnauthorizedMessage) { StatusCode = StatusCodes.Status401Unauthorized };
+            }
 
             var mongo = MongoDefinition.MongoInstance;
             var deviceTypes = mongo.GetAllDeviceTypes();


### PR DESCRIPTION
<!--
These comments inside these brackets will not appear in the pull request.

The pull request should be linked to either:
 - a task (i.e., use 'Closes #TaskID' or 'Resolves #TaskID')
 - a bug (i.e., use 'Closes #BugID' or 'Fixes #BugID')

For more details, see: https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes #406

Adds authentication to the device type endpoints. I also set some of the endpoints to use GetFilteredDevices instead of GetAllDevices where appropriate.
