### PR TITLE
Add count to return object for GetDeviceType endpoint

### DIFF
--- a/BEIMA.Backend.FT/DeviceTypeFT.cs
+++ b/BEIMA.Backend.FT/DeviceTypeFT.cs
@@ -85,6 +85,7 @@ namespace BEIMA.Backend.FT
             Assert.That(getDeviceType.Name, Is.EqualTo(device.Name));
             Assert.That(getDeviceType.Notes, Is.EqualTo(device.Notes));
             Assert.That(getDeviceType.Description, Is.EqualTo(device.Description));
+            Assert.That(getDeviceType.Count, Is.EqualTo(0));
             Assert.That(getDeviceType.Fields, Is.Not.Null.And.Not.Empty);
             Assert.That(getDeviceType.Fields?.Count, Is.EqualTo(device.Fields.Count));
             if (getDeviceType.Fields != null)

--- a/BEIMA.Backend.FT/DeviceTypeFT.cs
+++ b/BEIMA.Backend.FT/DeviceTypeFT.cs
@@ -387,5 +387,72 @@ namespace BEIMA.Backend.FT
                 Assert.That(updatedDeviceType.Fields, Contains.Key(key));
             }
         }
+
+        [Test]
+        public async Task DeviceAndDeviceTypeInDatabase_GetDeviceType_ReturnsDeviceTypeWithCount()
+        {
+            // ARRANGE
+            var origDeviceType = new DeviceTypeAdd
+            {
+                Description = "Boiler description.",
+                Name = "Boiler",
+                Notes = "Some boiler notes.",
+                Fields = new List<string>
+                {
+                    "Boiler Type",
+                    "Fuel Input Rate",
+                    "Output",
+                },
+            };
+
+            var deviceTypeId = await TestClient.AddDeviceType(origDeviceType);
+            var origItem = await TestClient.GetDeviceType(deviceTypeId);
+
+            var origDevice = new Device()
+            {
+                DeviceTag = "B-34",
+                DeviceTypeId = deviceTypeId,
+                Fields = new Dictionary<string, string> {
+                    { origItem.Fields?.Keys?.ToList()[0] ?? "Bad Fields", "Tall boiler." },
+                    { origItem.Fields?.Keys?.ToList()[1] ?? "Bad Fields", "23" },
+                    { origItem.Fields?.Keys?.ToList()[2] ?? "Bad Fields", "38" },
+                },
+                Location = new DeviceLocation()
+                {
+                    BuildingId = null,
+                    Latitude = "78.6",
+                    Longitude = "43.2",
+                    Notes = "Some notes."
+                },
+                Manufacturer = "Generic Inc.",
+                ModelNum = "1234",
+                Notes = "Some notes.",
+                SerialNum = "4321",
+                YearManufactured = 2001,
+            };
+
+            var deviceId = await TestClient.AddDevice(origDevice);
+
+            // ACT
+            var deviceType = await TestClient.GetDeviceType(deviceTypeId);
+
+            // ASSERT
+            Assert.That(deviceType.Name, Is.EqualTo(origDeviceType.Name));
+            Assert.That(deviceType.Notes, Is.EqualTo(origDeviceType.Notes));
+            Assert.That(deviceType.Description, Is.EqualTo(origDeviceType.Description));
+            Assert.That(deviceType.Count, Is.EqualTo(1));
+            Assert.That(deviceType.Fields, Is.Not.Null.And.Not.Empty);
+            Assert.That(deviceType.Fields?.Count, Is.EqualTo(origDeviceType.Fields.Count));
+            if (deviceType.Fields != null)
+            {
+                foreach (var key in deviceType.Fields.Keys)
+                {
+                    Assert.That(Guid.TryParse(key, out _), Is.True);
+                }
+            }
+            Assert.That(deviceType.Fields, Contains.Value(origDeviceType.Fields[0]));
+            Assert.That(deviceType.Fields, Contains.Value(origDeviceType.Fields[1]));
+            Assert.That(deviceType.Fields, Contains.Value(origDeviceType.Fields[2]));
+        }
     }
 }

--- a/BEIMA.Backend.FT/TestObjects.cs
+++ b/BEIMA.Backend.FT/TestObjects.cs
@@ -91,6 +91,9 @@ namespace BEIMA.Backend.FT
 
             [JsonProperty(PropertyName = "notes")]
             public string? Notes { get; set; }
+
+            [JsonProperty(PropertyName = "count")]
+            public int? Count { get; set; }
         }
 
         public class DeviceUpdate : Device

--- a/BEIMA.Backend.Test/DeviceTypeFunctions/GetDeviceTypeTest.cs
+++ b/BEIMA.Backend.Test/DeviceTypeFunctions/GetDeviceTypeTest.cs
@@ -106,6 +106,7 @@ namespace BEIMA.Backend.Test.DeviceTypeFunctions
 
             // ASSERT
             Assert.DoesNotThrow(() => mockDb.Verify(mock => mock.GetDeviceType(It.IsAny<ObjectId>()), Times.Once));
+            Assert.DoesNotThrow(() => mockDb.Verify(mock => mock.GetFilteredDevices(It.IsAny<FilterDefinition<BsonDocument>>()), Times.Once));
 
             Assert.That(response, Is.TypeOf(typeof(OkObjectResult)));
             Assert.That(((OkObjectResult)response).StatusCode, Is.EqualTo((int)HttpStatusCode.OK));

--- a/BEIMA.Backend.Test/DeviceTypeFunctions/GetDeviceTypeTest.cs
+++ b/BEIMA.Backend.Test/DeviceTypeFunctions/GetDeviceTypeTest.cs
@@ -3,6 +3,7 @@ using BEIMA.Backend.MongoService;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using MongoDB.Bson;
+using MongoDB.Driver;
 using Moq;
 using NUnit.Framework;
 using System;
@@ -92,6 +93,9 @@ namespace BEIMA.Backend.Test.DeviceTypeFunctions
             mockDb.Setup(mock => mock.GetDeviceType(It.Is<ObjectId>(oid => oid == new ObjectId(testId))))
                   .Returns(dbDeviceType.GetBsonDocument())
                   .Verifiable();
+            mockDb.Setup(mock => mock.GetFilteredDevices(It.IsAny<FilterDefinition<BsonDocument>>()))
+                  .Returns(new List<BsonDocument>())
+                  .Verifiable();
             MongoDefinition.MongoInstance = mockDb.Object;
 
             var request = CreateHttpRequest(RequestMethod.GET);
@@ -109,6 +113,7 @@ namespace BEIMA.Backend.Test.DeviceTypeFunctions
             Assert.That(device["name"], Is.EqualTo("Boiler"));
             Assert.That(device["description"], Is.EqualTo("Describes a boiler."));
             Assert.That(device["notes"], Is.EqualTo("Some notes."));
+            Assert.That(device["count"], Is.EqualTo(0));
         }
 
         #endregion SuccessTests

--- a/BEIMA.Backend/DeviceTypeFunctions/GetDeviceType.cs
+++ b/BEIMA.Backend/DeviceTypeFunctions/GetDeviceType.cs
@@ -36,13 +36,19 @@ namespace BEIMA.Backend.DeviceTypeFunctions
 
             // Retrieve the device type from the database.
             ObjectId oid = new ObjectId(id);
-            BsonDocument doc = MongoDefinition.MongoInstance.GetDeviceType(oid);
+            var mongo = MongoDefinition.MongoInstance;
+            BsonDocument doc = mongo.GetDeviceType(oid);
 
             // Check that the device type returned is not null.
             if (doc is null)
             {
                 return new NotFoundObjectResult(Resources.DeviceTypeNotFoundMessage);
             }
+
+            // Find the total number of devices that are match this deviceType, and return the count of devices in the return object.
+            var filter = MongoFilterGenerator.GetEqualsFilter("deviceTypeId", doc.GetValue("_id"));
+            var deviceCount = mongo.GetFilteredDevices(filter).Count;
+            doc.Add("count", deviceCount);
 
             // Return the device type.
             var dotNetObj = BsonTypeMapper.MapToDotNetValue(doc);


### PR DESCRIPTION
<!--
These comments inside these brackets will not appear in the pull request.

The pull request should be linked to either:
 - a task (i.e., use 'Closes #TaskID' or 'Resolves #TaskID')
 - a bug (i.e., use 'Closes #BugID' or 'Fixes #BugID')

For more details, see: https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes #410

This PR implements including the Count in the return object for GetDeviceType. Basically, this count is referring to the number of Devices that are currently in the "devices" collection, with this specific DeviceTypeId being used.
