### PR TITLE
Clearing previous custom fields when the device type changes

### DIFF
--- a/BEIMA.Client/src/pages/Devices/AddDevicePage.js
+++ b/BEIMA.Client/src/pages/Devices/AddDevicePage.js
@@ -98,16 +98,17 @@ const AddDevicePage = () => {
     setSelectedDeviceType(deviceTypeFields.response);
     setDeviceTypeDropDownStyle(styles.dropDownSelected);
     
-    //retireve the values from teh response to label the form elements
+    //retrieve the values from teh response to label the form elements
     let fieldLabels = Object.values(deviceTypeFields.response.fields);
+    let allFields = mandatoryDeviceFields;
     
     //append the custom labels to the form generation object
     for(let i = 0; i < fieldLabels.length; i++) {
-      deviceFields[fieldLabels[i]] = "";
+      allFields[fieldLabels[i]] = "";
     }
 
     //add them to the forms errors lists
-    setDeviceFields(deviceFields);
+    setDeviceFields(allFields);
     setErrors({});
   }
   
@@ -183,6 +184,7 @@ const AddDevicePage = () => {
           for(let i = 0; i < formFields.length; i++){
             formFields[i].value = "";
           }
+          setDeviceFields(mandatoryDeviceFields);
           Notifications.success("Add Device Successful", "Adding Device completed successfully.");
         } else {
           Notifications.error("Unable to Add Device", `Adding Device failed.`);

--- a/BEIMA.Client/src/pages/Devices/AddDevicePage.js
+++ b/BEIMA.Client/src/pages/Devices/AddDevicePage.js
@@ -98,7 +98,7 @@ const AddDevicePage = () => {
     setSelectedDeviceType(deviceTypeFields.response);
     setDeviceTypeDropDownStyle(styles.dropDownSelected);
     
-    //retrieve the values from teh response to label the form elements
+    //retrieve the values from the response to label the form elements
     let fieldLabels = Object.values(deviceTypeFields.response.fields);
     let allFields = mandatoryDeviceFields;
     


### PR DESCRIPTION
<!--
These comments inside these brackets will not appear in the pull request.

The pull request should be linked to either:
 - a task (i.e., use 'Closes #TaskID' or 'Resolves #TaskID')
 - a bug (i.e., use 'Closes #BugID' or 'Fixes #BugID')

For more details, see: https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes #475

When we change the device type when trying to add a device, the custom fields from the previously selected device type are not shown anymore.
