### PR TITLE
changed build order in docker containers to leverage cached layers

### DIFF
--- a/BEIMA.Backend/Dockerfile
+++ b/BEIMA.Backend/Dockerfile
@@ -12,10 +12,6 @@ WORKDIR /beima
 RUN apt update
 # Set time zone env variable and install tzdata package using it
 RUN TZ=Etc/UTC apt-get -y install tzdata
-# Move all required folders into the container, must have all projects or it won't buildsince the others are referenced in the Backend csproj
-COPY ./BEIMA.Backend/ /beima/BEIMA.Backend/
-COPY ./BEIMA.Backend.Test/ /beima/BEIMA.Backend.Test
-COPY ./BEIMA.Backend.FT/ /beima/BEIMA.Backend.FT
 #i Install tools
 RUN apt install -y wget
 # Get MS installer package
@@ -34,5 +30,11 @@ RUN apt-get install -y dotnet-sdk-6.0
 WORKDIR /beima/BEIMA.Backend
 # Set Environment Variable to ignore globalization
 RUN export DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1
+# Turn off MS Telemetry data
+RUN export DOTNET_CLI_TELEMETRY_OPTOUT=1
+# Move all required folders into the container, must have all projects or it won't buildsince the others are referenced in the Backend csproj
+COPY ./BEIMA.Backend/ /beima/BEIMA.Backend/
+COPY ./BEIMA.Backend.Test/ /beima/BEIMA.Backend.Test
+COPY ./BEIMA.Backend.FT/ /beima/BEIMA.Backend.FT
 # Start the API
 ENTRYPOINT ["func", "start", "BEIMA.Backend.csproj"]

--- a/BEIMA.Client/Dockerfile
+++ b/BEIMA.Client/Dockerfile
@@ -12,8 +12,6 @@ WORKDIR /beima
 RUN apt update
 # Set time zone env variable and install tzdata package using it
 RUN TZ=Etc/UTC apt-get -y install tzdata
-# Move all required folders into the container
-COPY ./BEIMA.Client/ /beima/BEIMA.Client/
 # Install build utilities
 RUN apt install -y curl
 # Get the latest (ver 16) node server PPA
@@ -22,11 +20,16 @@ RUN curl -fsSL https://deb.nodesource.com/setup_16.x | bash
 RUN apt install -y nodejs
 # Move work directory to client
 WORKDIR /beima/BEIMA.Client
+# Import package lists
+COPY ./BEIMA.Client/package.json /beima/BEIMA.Client/
+COPY ./BEIMA.Client/package-lock.json /beima/BEIMA.Client/
 # Install Node dependencies
 RUN npm i
-# Build client in production mode
-RUN npm run build
 # Install web server
 RUN npm install -g serve
+# Move all required folders into the container
+COPY ./BEIMA.Client/ /beima/BEIMA.Client/
+# Build client in production mode
+RUN npm run build
 # Run the front end
 CMD ["serve", "-s", "build"]


### PR DESCRIPTION
<!--
These comments inside these brackets will not appear in the pull request.

The pull request should be linked to either:
 - a task (i.e., use 'Closes #TaskID' or 'Resolves #TaskID')
 - a bug (i.e., use 'Closes #BugID' or 'Fixes #BugID')

For more details, see: https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes #492

Moving the file copy directives for the API to the end of the Dockerfile will allow cached build stages to be used when files are changed for the backend since the software to run the API does not need to be reinstalled every time
Need to set the telemetry bit to keep MS from snooping

moving the package list files only before the rest of the source allows cached layers to be used for the front end if no packages have changed (cuts out long "npm i" time)
