### PR TITLE
Wrap text when text overflows

### DIFF
--- a/BEIMA.Client/src/pages/DeviceTypes/AddDeviceTypePage.js
+++ b/BEIMA.Client/src/pages/DeviceTypes/AddDeviceTypePage.js
@@ -35,8 +35,8 @@ const AddDeviceTypePage = () => {
   const [setPageName] = useOutletContext();
   const [errorMessage, setErrorMessage] = useState('');
   const [isInvalid, setIsInvalid] = useState(false);
+  const [field, setField] = useState("");
   let fullTypeJSON = {};
-  let field;
 
   useEffect(() => {
       setPageName('Add Device Type')
@@ -63,7 +63,7 @@ const AddDeviceTypePage = () => {
     setIsInvalid(false);
     let newList = customDeviceFields.concat(newField);
     setCustomDeviceFields(newList);
-    event.target.form.elements.newFieldForm.value = "";
+    setField("")
   }
 
   async function saveDeviceTypeToDb(addButtonEvent){
@@ -171,7 +171,7 @@ const AddDeviceTypePage = () => {
           <Form>
             <Form.Group>
               <Form.Label>Add Custom Field</Form.Label>
-              <Form.Control name="newFieldForm" type="text" placeholder="Enter Field Name" id="newField" isInvalid={isInvalid} value={field} onChange={(event) => {field = event.target.value; setIsInvalid(false)}} maxLength={Constants.MAX_INPUT_CHARACTER_LENGTH}/> 
+              <Form.Control name="newFieldForm" as="textarea" rows="1" type="text" placeholder="Enter Field Name" id="newField" isInvalid={isInvalid} value={field} onChange={(event) => {setField(event.target.value); setIsInvalid(false)}} maxLength={Constants.MAX_INPUT_CHARACTER_LENGTH}/> 
               <Form.Control.Feedback type='invalid'>{errorMessage}</Form.Control.Feedback>
             </Form.Group>
             <Button variant="primary" type="button" className={styles.button} id="addField" onClick={(event) => addField(field, event)}>

--- a/BEIMA.Client/src/shared/FormList/FormList.js
+++ b/BEIMA.Client/src/shared/FormList/FormList.js
@@ -7,7 +7,7 @@ const FormList = ({fields}) => {
         {fields.map(element =>
           <Form.Group key={element} id={element}>
             <Form.Label>{element}</Form.Label>
-            <Form.Control id={"input" + element} type="text" name={element} placeholder={"Enter " + element} maxLength={Constants.MAX_INPUT_CHARACTER_LENGTH}/>
+            <Form.Control as="textarea" rows="1" id={"input" + element} type="text" name={element} placeholder={"Enter " + element} maxLength={Constants.MAX_INPUT_CHARACTER_LENGTH}/>
           </Form.Group>
         )} 
       </div>

--- a/BEIMA.Client/src/shared/FormList/FormListWithErrorFeedback.js
+++ b/BEIMA.Client/src/shared/FormList/FormListWithErrorFeedback.js
@@ -9,7 +9,7 @@ const FormList = ({fields, errors, changeHandler}) => {
             <Form.Label>{element}</Form.Label>
             {element.toString().toLowerCase().includes("year") ?
               <Form.Control id={"input" + element} type="text" name={element} placeholder={"Enter " + element} isInvalid={errors[element]} maxLength={Constants.MAX_YEAR_LENGTH} onChange={changeHandler}/>
-            : <Form.Control id={"input" + element} type={element.toLowerCase().includes("password") ? 'password' : 'text'} name={element} placeholder={"Enter " + element} isInvalid={errors[element]} maxLength={Constants.MAX_INPUT_CHARACTER_LENGTH} onChange={changeHandler}/>}
+            : <Form.Control as="textarea" rows="1" id={"input" + element} type={element.toLowerCase().includes("password") ? 'password' : 'text'} name={element} placeholder={"Enter " + element} isInvalid={errors[element]} maxLength={Constants.MAX_INPUT_CHARACTER_LENGTH} onChange={changeHandler}/>}
               <Form.Control.Feedback type='invalid'> { errors[element]}</Form.Control.Feedback>
           </Form.Group>
         )} 


### PR DESCRIPTION
<!--
These comments inside these brackets will not appear in the pull request.

The pull request should be linked to either:
 - a task (i.e., use 'Closes #TaskID' or 'Resolves #TaskID')
 - a bug (i.e., use 'Closes #BugID' or 'Fixes #BugID')

For more details, see: https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes #446

This PR implements having text inputs wrap when there is too much text. Essentially, I replaced all those fields with textareas, and users will be able to scroll and manually expand the textarea when they need more room.

This PR also fixes a bug with the custom field input on AddDeviceTypePage. The "fields" variable was not using a state variable, so it has been updated to use useState().
