### PR TITLE
Add api key to env for build/deploy

### DIFF
--- a/.github/workflows/deploy-client.yaml
+++ b/.github/workflows/deploy-client.yaml
@@ -39,3 +39,4 @@ jobs:
         app_artifact_location: ${{ env.APP_ARTIFACT_LOCATION }}
       env:
         REACT_APP_API_URL: ${{ env.BACKEND_API }}
+        REACT_APP_MAPBOX_TOKEN: "pk.eyJ1Ijoiam9lbW9vciIsImEiOiJjbDIzbmM4bDYxN2Z5M2NueHJ1ZDBuejR5In0.cJmcLf6OgSmM8Tk_atv4-A"

--- a/.github/workflows/deploy-client.yaml
+++ b/.github/workflows/deploy-client.yaml
@@ -39,4 +39,4 @@ jobs:
         app_artifact_location: ${{ env.APP_ARTIFACT_LOCATION }}
       env:
         REACT_APP_API_URL: ${{ env.BACKEND_API }}
-        REACT_APP_MAPBOX_TOKEN: "pk.eyJ1Ijoiam9lbW9vciIsImEiOiJjbDIzbmM4bDYxN2Z5M2NueHJ1ZDBuejR5In0.cJmcLf6OgSmM8Tk_atv4-A"
+        REACT_APP_MAPBOX_TOKEN: ${{ env.REACT_MAP_API_TOKEN }}


### PR DESCRIPTION
<!--
These comments inside these brackets will not appear in the pull request.

The pull request should be linked to either:
 - a task (i.e., use 'Closes #TaskID' or 'Resolves #TaskID')
 - a bug (i.e., use 'Closes #BugID' or 'Fixes #BugID')

For more details, see: https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes #504

Adds the env client variable so that we can access the map api key on the deployed server.
