### PR TITLE
removed unneeded port bindings to host machine

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -38,8 +38,7 @@ services:
     image: minio/minio:latest
     command: server /data
     ports:
-      - "9000"
-      - "9001:9001"
+      - "9000:9000"
     networks:
       internal:
         ipv4_address: 192.168.0.4

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -17,7 +17,7 @@ services:
   database:
     image: mongo
     ports:
-      - "27017:27017"
+      - "27017"
     volumes:
       - './data/mongo:/data/db'
     networks:
@@ -38,7 +38,7 @@ services:
     image: minio/minio:latest
     command: server /data
     ports:
-      - "9000:9000"
+      - "9000"
       - "9001:9001"
     networks:
       internal:


### PR DESCRIPTION
<!--
These comments inside these brackets will not appear in the pull request.

The pull request should be linked to either:
 - a task (i.e., use 'Closes #TaskID' or 'Resolves #TaskID')
 - a bug (i.e., use 'Closes #BugID' or 'Fixes #BugID')

For more details, see: https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes #508

MongoDb and Minio are accessed via network name or IP, they do not need to use the host network so their binding has ben removed
