### PR TITLE
Dynamic reload on edit DeviceType and Building

### DIFF
--- a/BEIMA.Client/src/pages/Building/BuildingPage.js
+++ b/BEIMA.Client/src/pages/Building/BuildingPage.js
@@ -13,6 +13,7 @@ const BuildingPage = () => {
   const [setPageName] = useOutletContext();
   const [loading, setLoading] = useState(true);
   const [building, setBuilding] = useState(null);
+  const [buildingChanged, setBuildingChanged] = useState(false);
 
   const { id } = useParams();
 
@@ -21,10 +22,11 @@ const BuildingPage = () => {
       const building = (await GetBuilding(id)).response;
       setBuilding(building)
       setLoading(false)
+      setBuildingChanged(false);
     }
    loadData();
     setPageName('View Building')
-  },[setPageName, id])
+  },[setPageName, buildingChanged, id])
 
   /**
    * Renders an card styled input that lets a user change a field's input
@@ -108,6 +110,8 @@ const BuildingPage = () => {
       if(updateResult.status === Constants.HTTP_SUCCESS){
         Notifications.success("Update Building Successful", `Building ${name} updated successfully.`);
         setEditable(false);
+        setLoading(true);
+        setBuildingChanged(true);
       } else {
         Notifications.error("Unable to Update Building", `Update of Building ${name} failed.`);
       }

--- a/BEIMA.Client/src/pages/DeviceTypes/DeviceTypePage.js
+++ b/BEIMA.Client/src/pages/DeviceTypes/DeviceTypePage.js
@@ -16,6 +16,7 @@ const DeviceTypePage = () => {
   const [deviceType, setDeviceType] = useState(null)
   const [loading, setLoading] = useState(true)
   const [setPageName] = useOutletContext();
+  const [deviceTypeChanged, setDeviceTypeChanged] = useState(false);
 
   const { typeId } = useParams();
 
@@ -28,9 +29,10 @@ const DeviceTypePage = () => {
       type['deletedFields'] = [];
       setDeviceType(type)
       setLoading(false)
+      setDeviceTypeChanged(false)
     }
     loadData()
-  },[typeId, setPageName])
+  },[typeId, deviceTypeChanged, setPageName])
 
   /**
    * Renders a card styled field in a device type.
@@ -136,6 +138,8 @@ const DeviceTypePage = () => {
         if(updateResult.status === Constants.HTTP_SUCCESS){
           Notifications.success("Update Device Type Successful", `Device Type ${item.name} updated successfully.`)
           setEditable(false)
+          setLoading(true);
+          setDeviceTypeChanged(true);
         } else {
           Notifications.error("Unable to Update Device Type", `Update of Device Type ${item.name} failed.`);
         }


### PR DESCRIPTION
<!--
These comments inside these brackets will not appear in the pull request.

The pull request should be linked to either:
 - a task (i.e., use 'Closes #TaskID' or 'Resolves #TaskID')
 - a bug (i.e., use 'Closes #BugID' or 'Fixes #BugID')

For more details, see: https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes #515 

This PR implements dynamic reload after an edit on the DeviceType and Building pages.
